### PR TITLE
feat: 거래 내역 조회 기능 추가

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="FrameworkDetectionExcludesConfiguration">
-    <file type="web" url="file://$PROJECT_DIR$" />
-  </component>
-  <component name="MavenProjectsManager">
-    <option name="originalFiles">
-      <list>
-        <option value="$PROJECT_DIR$/pom.xml" />
-      </list>
-    </option>
-  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ dependencies {
   implementation "org.apache.logging.log4j:log4j-slf4j-impl:${log4j2Version}"
   implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4:1.16'
 
+  //date
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
   // xml내 한글 처리
   implementation 'xerces:xercesImpl:2.12.2'

--- a/database.sql
+++ b/database.sql
@@ -169,6 +169,7 @@ CREATE TABLE `transaction` (
                                `type` ENUM('INCOME', 'EXPENSE') NOT NULL,
                                `amount` DECIMAL(10,2) NOT NULL,
                                `memo` TEXT,
+                               `analysis` VARCHAR(255),
                                PRIMARY KEY (`id`),
                                FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE,
                                FOREIGN KEY (`account_id`) REFERENCES `account`(`id`) ON DELETE CASCADE

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -24,14 +24,18 @@ import javax.sql.DataSource;
 @MapperScan(basePackages = {
         "org.scoula.user.mapper",
         "org.scoula.finance.mapper",
+        "org.scoula.transactions.mapper",
 })
 @ComponentScan(basePackages = {
         "org.scoula.security",
         "org.scoula.user.service",
         "org.scoula.common.redis",
-        "org.scoula.common.*" // 공통 유틸이나 예외 추가할 여지
+        "org.scoula.common.*", // 공통 유틸이나 예외 추가할 여지
         "org.scoula.finance.controller",
         "org.scoula.finance.service",
+        "org.scoula.transactions.service",
+        "org.scoula.transactions.util",
+        "org.scoula.transactions.exception",
 
 })
 @EnableTransactionManagement

--- a/src/main/java/org/scoula/config/ServletConfig.java
+++ b/src/main/java/org/scoula/config/ServletConfig.java
@@ -18,6 +18,7 @@ import java.util.List;
         "org.scoula.finance.service",
         "org.scoula.user.controller",
         "org.scoula.user.exception",
+        "org.scoula.transactions.controller",
 })
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/java/org/scoula/transactions/controller/TransactionController.java
+++ b/src/main/java/org/scoula/transactions/controller/TransactionController.java
@@ -1,0 +1,41 @@
+package org.scoula.transactions.controller;
+
+import io.swagger.annotations.*;
+import lombok.RequiredArgsConstructor;
+import org.scoula.transactions.dto.TransactionDTO;
+import org.scoula.transactions.dto.TransactionDetailDTO;
+import org.scoula.transactions.service.TransactionService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Api(tags = "거래내역 API")
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    @ApiOperation(value = "유저 기준 거래내역 조회", notes = "특정 유저 ID의 거래내역을 조회합니다. 거래일 기준 내림차순 정렬됩니다.")
+    @GetMapping("/users/{userId}/transactions")
+    public List<TransactionDTO> getTransactionsByUser(@ApiParam(value = "유저 ID") @PathVariable Long userId) {
+        return transactionService.getTransactionsByUserId(userId);
+    }
+
+    @ApiOperation(value = "계좌 기준 거래내역 조회", notes = "특정 계좌 ID의 거래내역을 조회합니다. 거래일 기준 내림차순 정렬됩니다.")
+    @GetMapping("/accounts/{accountId}/transactions")
+    public List<TransactionDTO> getTransactionsByAccount(@ApiParam(value = "계좌 ID") @PathVariable Long accountId) {
+        return transactionService.getTransactionsByAccountId(accountId);
+    }
+
+    @ApiOperation(value = "거래 상세 조회", notes = "거래 ID로 상세 정보를 조회합니다. 소비 분석이 없는 경우 rule-based 분석 후 DB에 저장됩니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "성공"),
+            @ApiResponse(code = 404, message = "거래 없음")
+    })
+    @GetMapping("/transactions/{id}")
+    public TransactionDetailDTO getTransactionDetail(@ApiParam(value = "거래 ID") @PathVariable Long id) {
+        return transactionService.getTransactionDetail(id);
+    }
+}

--- a/src/main/java/org/scoula/transactions/domain/Transaction.java
+++ b/src/main/java/org/scoula/transactions/domain/Transaction.java
@@ -1,0 +1,19 @@
+package org.scoula.transactions.domain;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class Transaction {
+    private Long id;
+    private Long userId;
+    private Long accountId;
+    private String place;
+    private LocalDateTime date;
+    private String category;
+    private String type; // INCOME or EXPENSE
+    private BigDecimal amount;
+    private String memo;
+}

--- a/src/main/java/org/scoula/transactions/dto/TransactionDTO.java
+++ b/src/main/java/org/scoula/transactions/dto/TransactionDTO.java
@@ -1,0 +1,23 @@
+package org.scoula.transactions.dto;
+
+import lombok.*;
+import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TransactionDTO {
+    private Long id;
+    private Double amount;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime date;
+
+    private String type;
+    private String category;
+    private String place;
+    private String accountName;
+}

--- a/src/main/java/org/scoula/transactions/dto/TransactionDetailDTO.java
+++ b/src/main/java/org/scoula/transactions/dto/TransactionDetailDTO.java
@@ -1,0 +1,25 @@
+package org.scoula.transactions.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TransactionDetailDTO {
+    private Long id;
+    private Long userId;
+    private String place;
+    private String category;
+    private String type;
+    private BigDecimal amount;
+    private LocalDateTime date;
+    private String memo;
+    private String accountName;
+    private String accountNumber;
+    private String analysisText;
+}

--- a/src/main/java/org/scoula/transactions/exception/TransactionNotFoundException.java
+++ b/src/main/java/org/scoula/transactions/exception/TransactionNotFoundException.java
@@ -1,0 +1,7 @@
+package org.scoula.transactions.exception;
+
+public class TransactionNotFoundException extends RuntimeException {
+    public TransactionNotFoundException(String id) {
+        super("거래내역을 찾을 수 없습니다. ID = " + id);
+    }
+}

--- a/src/main/java/org/scoula/transactions/mapper/TransactionMapper.java
+++ b/src/main/java/org/scoula/transactions/mapper/TransactionMapper.java
@@ -1,0 +1,18 @@
+package org.scoula.transactions.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.scoula.transactions.domain.Transaction;
+import org.scoula.transactions.dto.TransactionDTO;
+import org.scoula.transactions.dto.TransactionDetailDTO;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface TransactionMapper {
+    List<TransactionDTO> findByUserId(Long userId);
+    List<TransactionDTO> findByAccountId(Long accountId);
+    TransactionDetailDTO findById(Long id);
+    void updateAnalysisText(@Param("id") Long id, @Param("analysisText") String analysisText);
+    List<Transaction> findRecentTransactionsByUser(@Param("userId") Long userId,
+                                                   @Param("fromDate") LocalDateTime fromDate);
+}

--- a/src/main/java/org/scoula/transactions/service/TransactionService.java
+++ b/src/main/java/org/scoula/transactions/service/TransactionService.java
@@ -1,0 +1,12 @@
+package org.scoula.transactions.service;
+
+import org.scoula.transactions.dto.TransactionDTO;
+import org.scoula.transactions.dto.TransactionDetailDTO;
+
+import java.util.List;
+
+public interface TransactionService {
+    List<TransactionDTO> getTransactionsByUserId(Long userId);
+    List<TransactionDTO> getTransactionsByAccountId(Long accountId); // 추가
+    TransactionDetailDTO getTransactionDetail(Long id);
+}

--- a/src/main/java/org/scoula/transactions/service/TransactionServiceImpl.java
+++ b/src/main/java/org/scoula/transactions/service/TransactionServiceImpl.java
@@ -1,0 +1,49 @@
+package org.scoula.transactions.service;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.transactions.domain.Transaction;
+import org.scoula.transactions.dto.TransactionDTO;
+import org.scoula.transactions.dto.TransactionDetailDTO;
+import org.scoula.transactions.exception.TransactionNotFoundException;
+import org.scoula.transactions.mapper.TransactionMapper;
+import org.scoula.transactions.util.RuleBasedAnalyzer;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionServiceImpl implements TransactionService {
+
+    private final TransactionMapper transactionMapper;
+
+    @Override
+    public List<TransactionDTO> getTransactionsByUserId(Long userId) {
+        return transactionMapper.findByUserId(userId);
+    }
+
+    @Override
+    public List<TransactionDTO> getTransactionsByAccountId(Long accountId) {
+        return transactionMapper.findByAccountId(accountId); // 추가
+    }
+
+    @Override
+    public TransactionDetailDTO getTransactionDetail(Long id) {
+        TransactionDetailDTO dto = transactionMapper.findById(id);
+        if (dto == null) throw new TransactionNotFoundException("거래를 찾을 수 없습니다.");
+
+        if (dto.getAnalysisText() == null || dto.getAnalysisText().isEmpty()) {
+            List<Transaction> recent = transactionMapper.findRecentTransactionsByUser(
+                    dto.getUserId(), dto.getDate().minusDays(7)
+            );
+            String analysis = RuleBasedAnalyzer.analyze(dto, recent);
+            transactionMapper.updateAnalysisText(id, analysis);
+            dto.setAnalysisText(analysis);
+        }
+
+
+        return dto;
+    }
+
+
+}

--- a/src/main/java/org/scoula/transactions/util/RuleBasedAnalyzer.java
+++ b/src/main/java/org/scoula/transactions/util/RuleBasedAnalyzer.java
@@ -1,0 +1,58 @@
+package org.scoula.transactions.util;
+
+import org.scoula.transactions.dto.TransactionDetailDTO;
+import org.scoula.transactions.domain.Transaction;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class RuleBasedAnalyzer {
+
+    public static String analyze(TransactionDetailDTO dto, List<Transaction> recentTransactions) {
+        String category = dto.getCategory();
+        String place = dto.getPlace();
+        BigDecimal amount = dto.getAmount();
+        LocalDateTime date = dto.getDate();
+        String memo = dto.getMemo();
+
+        // 고액 식비
+        if ("식비".equalsIgnoreCase(category) && amount.compareTo(new BigDecimal("100000")) > 0) {
+            return "이번 식비는 10만원 이상으로 고액 소비입니다.\n지출 내역을 다시 확인해보세요.";
+        }
+
+        // 최근 7일간 식비 3회 이상
+        long countCategory = recentTransactions.stream()
+                .filter(t -> "식비".equalsIgnoreCase(t.getCategory()))
+                .count();
+        if ("식비".equalsIgnoreCase(category) && countCategory >= 3) {
+            return "최근 일주일간 식비 거래가 3회 이상 발생했어요.\n식비 예산 점검이 필요합니다.";
+        }
+
+        // 같은 장소 2회 이상
+        long samePlaceCount = recentTransactions.stream()
+                .filter(t -> place.equalsIgnoreCase(t.getPlace()))
+                .count();
+        if (samePlaceCount >= 2) {
+            return "같은 장소에서 반복 소비가 감지됐어요.\n패턴 소비가 아닌지 확인해보세요.";
+        }
+
+        // 야간 소비
+        int hour = date.getHour();
+        if (hour >= 22 || hour < 5) {
+            return "늦은 밤 시간대의 소비입니다.\n충동 소비가 아니었는지 생각해보세요.";
+        }
+
+        // 고액 쇼핑
+        if ("쇼핑".equalsIgnoreCase(category) && amount.compareTo(new BigDecimal("50000")) > 0) {
+            return "이번 쇼핑은 고액 소비입니다.\n계획된 소비인지 점검해보세요.";
+        }
+
+        // 메모 없음
+        if (memo == null || memo.trim().isEmpty()) {
+            return "이 거래에는 메모가 없습니다.\n기록 습관을 들이면 분석에 도움이 돼요.";
+        }
+
+        return "이번 소비는 이상 없이 정상 범위로 판단돼요.\n좋은 소비 습관을 유지하고 있어요!";
+    }
+}

--- a/src/main/resources/org/scoula/transactions/mapper/TransactionMapper.xml
+++ b/src/main/resources/org/scoula/transactions/mapper/TransactionMapper.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.scoula.transactions.mapper.TransactionMapper">
+
+    <select id="findByUserId" resultType="org.scoula.transactions.dto.TransactionDTO">
+        SELECT id, place, category, type, amount, date
+        FROM transaction
+        WHERE user_id = #{userId}
+        ORDER BY date DESC
+    </select>
+
+    <select id="findByAccountId" resultType="org.scoula.transactions.dto.TransactionDTO">
+        SELECT id, place, category, type, amount, date
+        FROM transaction
+        WHERE account_id = #{accountId}
+        ORDER BY date DESC
+    </select>
+
+    <select id="findById" resultType="org.scoula.transactions.dto.TransactionDetailDTO">
+        SELECT
+            t.id,
+            t.user_id,
+            t.place,
+            t.category,
+            t.type,
+            t.amount,
+            t.date,
+            t.memo,
+            t.analysis AS analysisText,
+            a.bank_name AS accountName,
+            a.account_number AS accountNumber
+        FROM transaction t
+                 JOIN account a ON t.account_id = a.id
+        WHERE t.id = #{id}
+    </select>
+
+    <update id="updateAnalysisText">
+        UPDATE transaction
+        SET analysis = #{analysisText}
+        WHERE id = #{id}
+    </update>
+
+    <select id="findRecentTransactionsByUser" resultType="org.scoula.transactions.domain.Transaction">
+        SELECT *
+        FROM transaction
+        WHERE user_id = #{userId}
+          AND date >= #{fromDate}
+    </select>
+</mapper>
+
+


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

거래 내역 조회 API 구현

## 📖 작업 내용 

특정 유저 ID에 따른 거래내역 리스트 조회 (거래일 기준 내림차순)
GET /api/users/{userId}/transactions


거래 ID로 상세정보 조회
GET /api/transactions/{id}
상세 정보 조회 시 소비 분석 내용 없으면 rule-based 에 의해 최초 1회만 분석 후 db 저장
→ 분석 없으면 rule-engine 호출 → 분석 내용 생성 코드 미완성
→ 결과 저장 (update)
→ 포함된 DTO 응답


특정 계좌 ID에 따른 거래내역 리스트 조회
GET /api/accounts/{accountId}/transactions

<img width="1304" height="415" alt="image" src="https://github.com/user-attachments/assets/2b5d2652-5e7e-42de-8655-904a92e472fb" />

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

closes #8 