### PR TITLE
feat: 챌린지 생성 API 추가

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -304,6 +304,9 @@ CREATE TABLE `challenge_category` (
                                       PRIMARY KEY (`ID`)
 );
 
+ALTER TABLE challenge_category ADD memo VARCHAR(255) DEFAULT NULL;
+
+
 -- 2. 챌린지 메인 테이블
 DROP TABLE IF EXISTS `challenge`;
 CREATE TABLE `challenge` (
@@ -325,6 +328,8 @@ CREATE TABLE `challenge` (
                              FOREIGN KEY (`category_id`) REFERENCES `challenge_category`(`ID`) ON DELETE CASCADE,
                              FOREIGN KEY (`writer_id`) REFERENCES `user`(`id`) ON DELETE CASCADE
 );
+ALTER TABLE challenge ADD use_password BOOLEAN DEFAULT FALSE;
+
 
 -- 3. 유저-챌린지 매핑 (참여 내역)
 DROP TABLE IF EXISTS `user_challenge`;
@@ -342,6 +347,9 @@ CREATE TABLE `user_challenge` (
                                   FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE,
                                   FOREIGN KEY (`challenge_id`) REFERENCES `challenge`(`ID`) ON DELETE CASCADE
 );
+
+ALTER TABLE user_challenge CHANGE joined_at created_at DATETIME DEFAULT CURRENT_TIMESTAMP;
+
 
 -- 4. 챌린지 진행 통계 (유저별 집계)
 DROP TABLE IF EXISTS `user_challenge_summary`;

--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -1,0 +1,37 @@
+package org.scoula.challenge.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.scoula.challenge.dto.ChallengeCreateRequestDTO;
+import org.scoula.challenge.dto.ChallengeCreateResponseDTO;
+import org.scoula.challenge.service.ChallengeService;
+import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.security.util.JwtUtil;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/challenge")
+@RequiredArgsConstructor
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/create")
+    public CommonResponseDTO<ChallengeCreateResponseDTO> createChallenge(
+            @RequestBody ChallengeCreateRequestDTO req,
+            HttpServletRequest request) {
+
+        String bearer = request.getHeader("Authorization");
+        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+
+        ChallengeCreateResponseDTO result = challengeService.createChallenge(userId, req);
+        return CommonResponseDTO.success("챌린지가 생성되었습니다.", result);
+    }
+}

--- a/src/main/java/org/scoula/challenge/domain/Challenge.java
+++ b/src/main/java/org/scoula/challenge/domain/Challenge.java
@@ -1,0 +1,25 @@
+package org.scoula.challenge.domain;
+
+import lombok.Data;
+import org.scoula.challenge.enums.ChallengeStatus;
+import org.scoula.challenge.enums.ChallengeType;
+
+import java.time.LocalDate;
+
+@Data
+public class Challenge {
+    private Long id;
+    private String title;
+    private Long categoryId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String description;
+    private ChallengeType type; // enum: PERSONAL, GROUP, (유저에게는 보여지지 않지만 common 타입도 존재)
+    private Integer maxParticipants; // 6 고정
+    private Integer password; //  숫자 4자리
+    private Boolean usePassword; // 비밀번호 사용 여부
+    private Long writerId;
+    private ChallengeStatus status; // ENUM('RECRUITING', 'IN_PROGRESS', 'COMPLETED')
+    private String goalType; // enum: 소비, 횟수 등
+    private Integer goalValue;
+}

--- a/src/main/java/org/scoula/challenge/dto/ChallengeCreateRequestDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeCreateRequestDTO.java
@@ -1,0 +1,19 @@
+package org.scoula.challenge.dto;
+
+import lombok.Data;
+import org.scoula.challenge.enums.ChallengeType;
+
+import java.time.LocalDate;
+
+@Data
+public class ChallengeCreateRequestDTO {
+    private String title; // 챌린지 제목
+    private Long categoryId; // 카테고리 ID
+    private String description; // 설명
+    private LocalDate startDate; // 시작일
+    private LocalDate endDate; // 종료일
+    private ChallengeType type; // Enum
+    private Integer goalValue; // 목표 금액
+    private Boolean usePassword; // 비밀번호 사용 여부
+    private Integer password; // 비밀번호 (nullable)
+}

--- a/src/main/java/org/scoula/challenge/dto/ChallengeCreateResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeCreateResponseDTO.java
@@ -1,0 +1,11 @@
+package org.scoula.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ChallengeCreateResponseDTO {
+    private Long challengeId; // 생성된 챌린지 ID
+    private String creatorNickname;
+}

--- a/src/main/java/org/scoula/challenge/enums/ChallengeStatus.java
+++ b/src/main/java/org/scoula/challenge/enums/ChallengeStatus.java
@@ -1,0 +1,5 @@
+package org.scoula.challenge.enums;
+
+public enum ChallengeStatus {
+    RECRUITING, IN_PROGRESS, COMPLETED
+}

--- a/src/main/java/org/scoula/challenge/enums/ChallengeType.java
+++ b/src/main/java/org/scoula/challenge/enums/ChallengeType.java
@@ -1,0 +1,5 @@
+package org.scoula.challenge.enums;
+
+public enum ChallengeType {
+    PERSONAL, GROUP, COMMON
+}

--- a/src/main/java/org/scoula/challenge/exception/ChallengeDurationTooShortException.java
+++ b/src/main/java/org/scoula/challenge/exception/ChallengeDurationTooShortException.java
@@ -1,0 +1,10 @@
+package org.scoula.challenge.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeDurationTooShortException extends BaseException {
+    public ChallengeDurationTooShortException() {
+        super("챌린지 기간은 최소 3일 이상이어야 합니다.", 400);
+    }
+}
+

--- a/src/main/java/org/scoula/challenge/exception/ChallengeGoalTooSmallException.java
+++ b/src/main/java/org/scoula/challenge/exception/ChallengeGoalTooSmallException.java
@@ -1,0 +1,10 @@
+package org.scoula.challenge.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeGoalTooSmallException extends BaseException {
+    public ChallengeGoalTooSmallException() {
+        super("챌린지 목표 금액은 최소 1,000원 이상이어야 합니다.", 400);
+    }
+}
+

--- a/src/main/java/org/scoula/challenge/exception/ChallengeLimitExceededException.java
+++ b/src/main/java/org/scoula/challenge/exception/ChallengeLimitExceededException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeLimitExceededException extends BaseException {
+    public ChallengeLimitExceededException(String type) {
+        super("이미 " + type + " 챌린지를 최대 참여 중입니다.", 400);
+    }
+}

--- a/src/main/java/org/scoula/challenge/exception/ChallengePasswordFormatException.java
+++ b/src/main/java/org/scoula/challenge/exception/ChallengePasswordFormatException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengePasswordFormatException extends BaseException {
+    public ChallengePasswordFormatException() {
+        super("비밀번호는 숫자 4자리여야 합니다.", 400);
+    }
+}

--- a/src/main/java/org/scoula/challenge/exception/ChallengePasswordRequiredException.java
+++ b/src/main/java/org/scoula/challenge/exception/ChallengePasswordRequiredException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengePasswordRequiredException extends BaseException {
+    public ChallengePasswordRequiredException() {
+        super("비밀번호 사용 여부가 true일 때는 비밀번호 입력이 필수입니다.", 400);
+    }
+}

--- a/src/main/java/org/scoula/challenge/exception/ChallengeStartTooLateException.java
+++ b/src/main/java/org/scoula/challenge/exception/ChallengeStartTooLateException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeStartTooLateException extends BaseException {
+    public ChallengeStartTooLateException() {
+        super("챌린지 시작일은 생성일 기준 일주일 이내여야 합니다.", 400);
+    }
+}

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -1,0 +1,20 @@
+package org.scoula.challenge.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.scoula.challenge.domain.Challenge;
+
+@Mapper
+public interface ChallengeMapper {
+    void insertChallenge(Challenge challenge);
+
+    void insertUserChallenge(@Param("userId") Long userId,
+                             @Param("challengeId") Long challengeId,
+                             @Param("isCreator") boolean isCreator,
+                             @Param("isCompleted") boolean isCompleted,
+                             @Param("actualValue") int actualValue,
+                             @Param("isSuccess") boolean isSuccess);
+
+    int countUserOngoingChallenges(@Param("userId") Long userId, @Param("type") String type);
+}
+

--- a/src/main/java/org/scoula/challenge/service/ChallengeService.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeService.java
@@ -1,0 +1,8 @@
+package org.scoula.challenge.service;
+
+import org.scoula.challenge.dto.ChallengeCreateRequestDTO;
+import org.scoula.challenge.dto.ChallengeCreateResponseDTO;
+
+public interface ChallengeService {
+    ChallengeCreateResponseDTO createChallenge(Long userId, ChallengeCreateRequestDTO req);
+}

--- a/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
@@ -1,0 +1,76 @@
+package org.scoula.challenge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.challenge.domain.Challenge;
+import org.scoula.challenge.dto.ChallengeCreateRequestDTO;
+import org.scoula.challenge.dto.ChallengeCreateResponseDTO;
+import org.scoula.challenge.enums.ChallengeStatus;
+import org.scoula.challenge.enums.ChallengeType;
+import org.scoula.challenge.exception.*;
+import org.scoula.challenge.mapper.ChallengeMapper;
+import org.scoula.user.mapper.UserMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeServiceImpl implements ChallengeService {
+
+    private final ChallengeMapper challengeMapper;
+    private final UserMapper userMapper;
+
+    @Override
+    public ChallengeCreateResponseDTO createChallenge(Long userId, ChallengeCreateRequestDTO req) {
+        // 1. 챌린지 참여 제한
+        int count = challengeMapper.countUserOngoingChallenges(userId, req.getType().name());
+        if (count >= 3) throw new ChallengeLimitExceededException(req.getType().name());
+
+        // 2. 날짜 유효성 체크
+        if (req.getStartDate().isAfter(req.getEndDate())) throw new IllegalArgumentException("시작일은 종료일보다 이후일 수 없습니다.");
+        long days = ChronoUnit.DAYS.between(req.getStartDate(), req.getEndDate()) + 1;
+        if (days < 3) throw new ChallengeDurationTooShortException();
+        if (ChronoUnit.DAYS.between(LocalDate.now(), req.getStartDate()) > 7) throw new ChallengeStartTooLateException();
+
+        // 3. 목표 금액 검증
+        if (req.getGoalValue() < 1000) throw new ChallengeGoalTooSmallException();
+
+        // 4. 비밀번호 검증
+        if (Boolean.TRUE.equals(req.getUsePassword())) {
+            if (req.getPassword() == null) {
+                throw new ChallengePasswordRequiredException();
+            }
+            if (!String.valueOf(req.getPassword()).matches("\\d{4}")) {
+                throw new ChallengePasswordFormatException();
+            }
+        }
+
+        // 5. Challenge 생성
+        Challenge challenge = new Challenge();
+        challenge.setTitle(req.getTitle());
+        challenge.setCategoryId(req.getCategoryId());
+        challenge.setDescription(req.getDescription());
+        challenge.setStartDate(req.getStartDate());
+        challenge.setEndDate(req.getEndDate());
+        challenge.setType(req.getType());
+        challenge.setGoalValue(req.getGoalValue());
+        challenge.setUsePassword(req.getUsePassword());
+        challenge.setPassword(req.getUsePassword() ? req.getPassword() : null);
+        challenge.setWriterId(userId);
+        challenge.setMaxParticipants(req.getType() == ChallengeType.GROUP ? 6 : 1);
+        challenge.setStatus(ChallengeStatus.RECRUITING);
+        challenge.setGoalType("소비");
+
+        challengeMapper.insertChallenge(challenge);
+
+        // 6. UserChallenge 생성 (is_creator = true)
+        challengeMapper.insertUserChallenge(userId, challenge.getId(), true, false, 0, false);
+
+        // 7. 닉네임 조회
+        String nickname = userMapper.findNicknameById(userId);
+
+        return new ChallengeCreateResponseDTO(challenge.getId(), nickname);
+    }
+}
+

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -30,6 +30,7 @@ import javax.sql.DataSource;
         "org.scoula.dictionary.mapper",
         "org.scoula.bubble.mapper",
         "org.scoula.nhapi.mapper",
+        "org.scoula.challenge.mapper",
 })
 @ComponentScan(basePackages = {
         "org.scoula.security",
@@ -48,7 +49,7 @@ import javax.sql.DataSource;
         "org.scoula.bubble.service",
         "org.scoula.nhapi.service",
         "org.scoula.nhapi.util",
-
+        "org.scoula.challenge.service",
 
 })
 @EnableTransactionManagement
@@ -100,12 +101,4 @@ public class RootConfig {
         return new DataSourceTransactionManager(dataSource());
     }
 
-    /*
-    static {
-        Dotenv d = Dotenv.configure()
-                .filename(".env")
-                .load();
-        d.entries().forEach(entry -> System.setProperty(entry.getKey(), entry.getValue()));
-    }
-    */
 }

--- a/src/main/java/org/scoula/config/ServletConfig.java
+++ b/src/main/java/org/scoula/config/ServletConfig.java
@@ -25,6 +25,8 @@ import java.util.List;
         "org.scoula.bubble.controller",
         "org.scoula.transactions.exception",
         "org.scoula.nhapi.controller",
+        "org.scoula.challenge.controller",
+        "org.scoula.challenge.exception",
 })
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/java/org/scoula/user/mapper/UserMapper.java
+++ b/src/main/java/org/scoula/user/mapper/UserMapper.java
@@ -9,5 +9,6 @@ public interface UserMapper {
 
     void save(User user); // 회원가입
     User findByEmail(String email); // 이메일로 비밀번호 찾기
+    String findNicknameById(Long id);
     void updatePassword(User user); // 비밀번호 재발급
 }

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.scoula.challenge.mapper.ChallengeMapper">
+
+    <insert id="insertChallenge" parameterType="org.scoula.challenge.domain.Challenge" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO challenge
+        (title, category_id, start_date, end_date, description, type, max_participants, password, use_password, writer_id, status, goal_type, goal_value)
+        VALUES
+            (#{title}, #{categoryId}, #{startDate}, #{endDate}, #{description}, #{type}, #{maxParticipants}, #{password}, #{usePassword}, #{writerId}, #{status}, #{goalType}, #{goalValue})
+    </insert>
+
+    <insert id="insertUserChallenge">
+        INSERT INTO user_challenge (user_id, challenge_id, is_creator, is_completed, actual_value, is_success)
+        VALUES (#{userId}, #{challengeId}, #{isCreator}, #{isCompleted}, #{actualValue}, #{isSuccess});
+    </insert>
+
+    <select id="countUserOngoingChallenges" resultType="int">
+        SELECT COUNT(*) FROM user_challenge uc
+                                 JOIN challenge c ON uc.challenge_id = c.ID
+        WHERE uc.user_id = #{userId}
+          AND c.type = #{type}
+          AND c.status IN ('RECRUITING', 'IN_PROGRESS')
+    </select>
+
+</mapper>

--- a/src/main/resources/org/scoula/user/mapper/UserMapper.xml
+++ b/src/main/resources/org/scoula/user/mapper/UserMapper.xml
@@ -18,6 +18,10 @@
         SELECT * FROM user WHERE email = #{email}
     </select>
 
+    <select id="findNicknameById" resultType="string">
+        SELECT nickname FROM user_status WHERE id = #{id}
+    </select>
+
     <update id="updatePassword" parameterType="org.scoula.user.domain.User">
         UPDATE user
         SET password = #{password},


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

챌린지 생성 API 구현

## 📖 작업 내용 

1. challenge domain, controller, dto, service, mapper, enums 생성 챌린지 타입 선택 시, enums 에 정의된 값만 허용하도록 적용
2. 챌린지 생성시 일어날 수 있는 여러 예외 경우를 추가
> 기간이 너무 짧은 경우 (3일 이내)
> 목표 금액이 너무 작은 경우 (1000원 이내)
> 챌린지를 이미지 3개 참여중인 경우
> 비밀번호가 숫자 4자리가 아닌 경우
> 비밀번호 입력 안 한 경우
> 챌린지 시작일이 생성일 기준 일주일 보다 먼 경우

3. config 파일에 챌린지 경로 입력 완료
4. 챌린지 생성 응답시, 데이터에 유저 닉네임 포함되도록 수정
-> UserMapper , UserMapper.xml 에 닉네임 조회하는 추가
5. 챌린지 생성시, user challenge 테이블에도 추가 

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- closes #58 