### PR TITLE
feat: 챌린지 상세 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,12 @@ bin/
 
 # 민감 정보 보호
 /src/main/resources/application.properties
+
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="file://$PROJECT_DIR$/database.sql" dialect="MySQL" />
+  </component>
+</project>

--- a/database.sql
+++ b/database.sql
@@ -329,6 +329,7 @@ CREATE TABLE `challenge` (
                              FOREIGN KEY (`writer_id`) REFERENCES `user`(`id`) ON DELETE CASCADE
 );
 ALTER TABLE challenge ADD use_password BOOLEAN DEFAULT FALSE;
+ALTER TABLE challenge ADD COLUMN participant_count INT DEFAULT 0;
 
 
 -- 3. 유저-챌린지 매핑 (참여 내역)

--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.scoula.challenge.dto.ChallengeCreateRequestDTO;
 import org.scoula.challenge.dto.ChallengeCreateResponseDTO;
+import org.scoula.challenge.dto.ChallengeDetailResponseDTO;
 import org.scoula.challenge.dto.ChallengeListResponseDTO;
 import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
@@ -48,5 +49,15 @@ public class ChallengeController {
         List<ChallengeListResponseDTO> challenges = challengeService.getChallenges(userId, type, status);
         return CommonResponseDTO.success("챌린지 리스트 조회 성공", challenges);
     }
+
+    @GetMapping("/{id}")
+    public CommonResponseDTO<ChallengeDetailResponseDTO> getChallengeDetail(@PathVariable("id") Long id,
+                                                                            HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+        ChallengeDetailResponseDTO detail = challengeService.getChallengeDetail(userId, id);
+        return CommonResponseDTO.success("챌린지 상세 조회 성공", detail);
+    }
+
 
 }

--- a/src/main/java/org/scoula/challenge/domain/Challenge.java
+++ b/src/main/java/org/scoula/challenge/domain/Challenge.java
@@ -22,4 +22,6 @@ public class Challenge {
     private ChallengeStatus status; // ENUM('RECRUITING', 'IN_PROGRESS', 'COMPLETED')
     private String goalType; // enum: 소비, 횟수 등
     private Integer goalValue;
+    private Integer participantCount;
+
 }

--- a/src/main/java/org/scoula/challenge/dto/ChallengeDetailResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeDetailResponseDTO.java
@@ -1,0 +1,30 @@
+package org.scoula.challenge.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import org.scoula.challenge.enums.ChallengeStatus;
+import org.scoula.challenge.enums.ChallengeType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+public class ChallengeDetailResponseDTO {
+    private Long id;
+    private String title;
+    private String description;
+    private ChallengeType type;
+    private ChallengeStatus status;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String goalType;
+    private Integer goalValue;
+    private Boolean isParticipating;
+    private Boolean isMine;
+    private Double myProgress;
+    private Integer participantsCount;
+
+    // GROUP 전용
+    private List<ChallengeMemberDTO> members;
+}

--- a/src/main/java/org/scoula/challenge/dto/ChallengeMemberDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeMemberDTO.java
@@ -1,0 +1,12 @@
+package org.scoula.challenge.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data // 기본 생성자 + setter 제공
+public class ChallengeMemberDTO {
+    private Long userId;
+    private String nickname;
+    private Double progress;
+    private String avatarImage;
+}

--- a/src/main/java/org/scoula/challenge/exception/ChallengeNotFoundException.java
+++ b/src/main/java/org/scoula/challenge/exception/ChallengeNotFoundException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeNotFoundException extends BaseException {
+    public ChallengeNotFoundException() {
+        super("해당 챌린지를 찾을 수 없습니다.", 404);
+    }
+}

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -3,6 +3,7 @@ package org.scoula.challenge.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.scoula.challenge.domain.Challenge;
+import org.scoula.challenge.dto.ChallengeMemberDTO;
 import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
 
@@ -31,7 +32,12 @@ public interface ChallengeMapper {
 
     Double getGroupAverageProgress(@Param("challengeId") Long challengeId);
 
-    int getParticipantsCount(@Param("challengeId") Long challengeId);
+    Challenge findChallengeById(@Param("challengeId") Long challengeId);
+
+    boolean isUserParticipating(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
+
+    List<ChallengeMemberDTO> getGroupMembersWithAvatar(@Param("challengeId") Long challengeId);
+
 
 }
 

--- a/src/main/java/org/scoula/challenge/service/ChallengeService.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeService.java
@@ -2,6 +2,7 @@ package org.scoula.challenge.service;
 
 import org.scoula.challenge.dto.ChallengeCreateRequestDTO;
 import org.scoula.challenge.dto.ChallengeCreateResponseDTO;
+import org.scoula.challenge.dto.ChallengeDetailResponseDTO;
 import org.scoula.challenge.dto.ChallengeListResponseDTO;
 import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
@@ -11,5 +12,5 @@ import java.util.List;
 public interface ChallengeService {
     ChallengeCreateResponseDTO createChallenge(Long userId, ChallengeCreateRequestDTO req);
     List<ChallengeListResponseDTO> getChallenges(Long userId, ChallengeType type, ChallengeStatus status);
-
+    ChallengeDetailResponseDTO getChallengeDetail(Long userId, Long challengeId);
 }

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -7,9 +7,9 @@
 
     <insert id="insertChallenge" parameterType="org.scoula.challenge.domain.Challenge" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO challenge
-        (title, category_id, start_date, end_date, description, type, max_participants, password, use_password, writer_id, status, goal_type, goal_value)
+        (title, category_id, start_date, end_date, description, type, max_participants, password, use_password, writer_id, status, goal_type, goal_value, participant_count)
         VALUES
-            (#{title}, #{categoryId}, #{startDate}, #{endDate}, #{description}, #{type}, #{maxParticipants}, #{password}, #{usePassword}, #{writerId}, #{status}, #{goalType}, #{goalValue})
+            (#{title}, #{categoryId}, #{startDate}, #{endDate}, #{description}, #{type}, #{maxParticipants}, #{password}, #{usePassword}, #{writerId}, #{status}, #{goalType}, #{goalValue}, #{participantCount})
     </insert>
 
     <insert id="insertUserChallenge">
@@ -55,5 +55,26 @@
         WHERE challenge_id = #{challengeId}
     </select>
 
+    <select id="findChallengeById" resultType="org.scoula.challenge.domain.Challenge">
+        SELECT * FROM challenge WHERE id = #{challengeId}
+    </select>
+
+    <select id="isUserParticipating" resultType="boolean">
+        SELECT COUNT(*) > 0 FROM user_challenge
+        WHERE user_id = #{userId} AND challenge_id = #{challengeId}
+    </select>
+
+    <select id="getGroupMembersWithAvatar" resultType="org.scoula.challenge.dto.ChallengeMemberDTO">
+    SELECT u.id AS userId,
+           us.nickname AS nickname,
+           (uc.actual_value * 1.0 / c.goal_value) AS progress,
+           a.avatar_image AS avatarImage
+    FROM user_challenge uc
+             JOIN user u ON uc.user_id = u.id
+             JOIN user_status us ON u.id = us.id
+             JOIN challenge c ON uc.challenge_id = c.id
+             LEFT JOIN avatar a ON u.id = a.id
+    WHERE uc.challenge_id = #{challengeId}
+</select>
 
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

챌린지 상세 조회 API 구현
챌린지 테이블 컬럼 수정
gitignore 파일 수정

## 📖 작업 내용 

#### 챌린지 상세 조회 API 구현

controller, service, mapper, mapper.xml 에 상세 조회 관련 코드 추가
dto 추가 : 상세조회 응답, 멤버 리스트
exception 추가 : 없는 챌린지를 조회했을 경우

#### 챌린지 테이블 컬럼 수정
참여인원수 컬럼 추가
-> 기존에 mapper 에 정의해둔 인원수 구하는 메서드 삭제

#### gitignore 파일 수정
다빈님이 올렸던 파일들 추가

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- closes #71 