### PR TITLE
feat: 챌린지 참여 신청 API 구현

### DIFF
--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -2,10 +2,7 @@ package org.scoula.challenge.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.scoula.challenge.dto.ChallengeCreateRequestDTO;
-import org.scoula.challenge.dto.ChallengeCreateResponseDTO;
-import org.scoula.challenge.dto.ChallengeDetailResponseDTO;
-import org.scoula.challenge.dto.ChallengeListResponseDTO;
+import org.scoula.challenge.dto.*;
 import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
 import org.scoula.challenge.service.ChallengeService;
@@ -57,6 +54,20 @@ public class ChallengeController {
         Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
         ChallengeDetailResponseDTO detail = challengeService.getChallengeDetail(userId, id);
         return CommonResponseDTO.success("챌린지 상세 조회 성공", detail);
+    }
+
+    @PostMapping("/{id}/join")
+    public CommonResponseDTO<?> joinChallenge(@PathVariable("id") Long challengeId,
+                                              @RequestBody(required = false) ChallengeJoinRequestDTO joinRequest,
+                                              HttpServletRequest request) {
+
+        String bearer = request.getHeader("Authorization");
+        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+
+        Integer password = (joinRequest != null) ? joinRequest.getPassword() : null;
+
+        challengeService.joinChallenge(userId, challengeId, password);
+        return CommonResponseDTO.success("챌린지 참여 신청이 완료되었습니다.");
     }
 
 

--- a/src/main/java/org/scoula/challenge/dto/ChallengeJoinRequestDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeJoinRequestDTO.java
@@ -1,0 +1,8 @@
+package org.scoula.challenge.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChallengeJoinRequestDTO {
+    private Integer password;
+}

--- a/src/main/java/org/scoula/challenge/enums/ChallengeStatus.java
+++ b/src/main/java/org/scoula/challenge/enums/ChallengeStatus.java
@@ -1,5 +1,8 @@
 package org.scoula.challenge.enums;
 
 public enum ChallengeStatus {
-    RECRUITING, IN_PROGRESS, COMPLETED
+    RECRUITING, // 모집 중
+    CLOSED,     // 모집 마감 (인원 다참)
+    IN_PROGRESS, // 시작일 도달 → 자동 업데이트
+    COMPLETED   // 종료
 }

--- a/src/main/java/org/scoula/challenge/exception/join/ChallengeAlreadyJoinedException.java
+++ b/src/main/java/org/scoula/challenge/exception/join/ChallengeAlreadyJoinedException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception.join;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeAlreadyJoinedException extends BaseException {
+    public ChallengeAlreadyJoinedException() {
+        super("이미 챌린지에 참여 중입니다.", 400);
+    }
+}

--- a/src/main/java/org/scoula/challenge/exception/join/ChallengeFullException.java
+++ b/src/main/java/org/scoula/challenge/exception/join/ChallengeFullException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception.join;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeFullException extends BaseException {
+    public ChallengeFullException() {
+        super("해당 챌린지는 참여 인원이 가득 찼습니다.", 409);
+    }
+}

--- a/src/main/java/org/scoula/challenge/exception/join/ChallengeLimitExceededException.java
+++ b/src/main/java/org/scoula/challenge/exception/join/ChallengeLimitExceededException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception.join;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeLimitExceededException extends BaseException {
+    public ChallengeLimitExceededException(String type) {
+        super("이미 " + type + " 타입의 챌린지를 3개까지 참여 중입니다.", 400);
+    }
+}

--- a/src/main/java/org/scoula/challenge/exception/join/ChallengePasswordMismatchException.java
+++ b/src/main/java/org/scoula/challenge/exception/join/ChallengePasswordMismatchException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception.join;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengePasswordMismatchException extends BaseException {
+    public ChallengePasswordMismatchException() {
+        super("비밀번호가 일치하지 않습니다.", 403);
+    }
+}

--- a/src/main/java/org/scoula/challenge/exception/join/ChallengeStatusException.java
+++ b/src/main/java/org/scoula/challenge/exception/join/ChallengeStatusException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception.join;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeStatusException extends BaseException {
+    public ChallengeStatusException() {
+        super("모집 중인 챌린지가 아닙니다.", 400);
+    }
+}

--- a/src/main/java/org/scoula/challenge/exception/join/InvalidChallengeTypeJoinException.java
+++ b/src/main/java/org/scoula/challenge/exception/join/InvalidChallengeTypeJoinException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception.join;
+
+import org.scoula.common.exception.BaseException;
+
+public class InvalidChallengeTypeJoinException extends BaseException {
+    public InvalidChallengeTypeJoinException() {
+        super("개인 챌린지에는 참여할 수 없습니다.", 403);
+    }
+}

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -38,6 +38,10 @@ public interface ChallengeMapper {
 
     List<ChallengeMemberDTO> getGroupMembersWithAvatar(@Param("challengeId") Long challengeId);
 
+    void incrementParticipantCount(@Param("challengeId") Long challengeId);
+
+    void updateChallengeStatus(@Param("challengeId") Long challengeId,
+                               @Param("status") String status);
 
 }
 

--- a/src/main/java/org/scoula/challenge/service/ChallengeService.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeService.java
@@ -13,4 +13,6 @@ public interface ChallengeService {
     ChallengeCreateResponseDTO createChallenge(Long userId, ChallengeCreateRequestDTO req);
     List<ChallengeListResponseDTO> getChallenges(Long userId, ChallengeType type, ChallengeStatus status);
     ChallengeDetailResponseDTO getChallengeDetail(Long userId, Long challengeId);
+    void joinChallenge(Long userId, Long challengeId, Integer password);
+
 }

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -65,16 +65,29 @@
     </select>
 
     <select id="getGroupMembersWithAvatar" resultType="org.scoula.challenge.dto.ChallengeMemberDTO">
-    SELECT u.id AS userId,
-           us.nickname AS nickname,
-           (uc.actual_value * 1.0 / c.goal_value) AS progress,
-           a.avatar_image AS avatarImage
-    FROM user_challenge uc
-             JOIN user u ON uc.user_id = u.id
-             JOIN user_status us ON u.id = us.id
-             JOIN challenge c ON uc.challenge_id = c.id
-             LEFT JOIN avatar a ON u.id = a.id
-    WHERE uc.challenge_id = #{challengeId}
-</select>
+        SELECT u.id AS userId,
+               us.nickname AS nickname,
+               (uc.actual_value * 1.0 / c.goal_value) AS progress,
+               a.avatar_image AS avatarImage
+        FROM user_challenge uc
+                 JOIN user u ON uc.user_id = u.id
+                 JOIN user_status us ON u.id = us.id
+                 JOIN challenge c ON uc.challenge_id = c.id
+                 LEFT JOIN avatar a ON u.id = a.id
+        WHERE uc.challenge_id = #{challengeId}
+    </select>
+
+    <update id="incrementParticipantCount">
+        UPDATE challenge
+        SET participant_count = participant_count + 1
+        WHERE id = #{challengeId}
+    </update>
+
+    <update id="updateChallengeStatus">
+        UPDATE challenge
+        SET status = #{status}
+        WHERE id = #{challengeId}
+    </update>
+
 
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
챌린지 참여 로직 보완 및 참여 제한/예외/보안 처리 개선

## 📖 작업 내용 
- 개인 챌린지(PERSONAL) 참여 시도 시 예외 발생하도록 서버 차단 로직 추가
- 그룹 챌린지(GROUP) 및 공통 챌린지(COMMON)만 참여 가능
- 유저가 챌린지 타입별로 최대 3개까지만 참여 가능하도록 제한
- 모집 상태가 아닌 챌린지에 참여 시도하면 예외 처리
- 그룹 챌린지 비밀번호 검증 추가 (불일치/누락 예외 처리)
- 참여 인원이 가득 찬 경우 예외 처리 및 상태를 CLOSED로 자동 변경
- 참여 API에서 비밀번호를 query → body 로 전달 방식 변경 (보안 강화)
- 관련 예외 클래스를 다음과 같이 분리:
  - ChallengeAlreadyJoinedException
  - ChallengeLimitExceededException
  - ChallengeFullException
  - ChallengeStatusException
  - ChallengePasswordMismatchException
  - InvalidChallengeTypeJoinException

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [x] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#126`)

## ✋ 질문 사항


## 🔗 관련 이슈
Closes #73 