### PR TITLE
feat: 챌린지 상태 자동 업데이트 스케줄러 및 수동 실행 API 추가

### DIFF
--- a/.idea/dataSources.local.xml
+++ b/.idea/dataSources.local.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="dataSourceStorageLocal" created-in="IU-243.26053.27">
+  <component name="dataSourceStorageLocal" created-in="IU-241.18034.62">
     <data-source name="@localhost" uuid="ca52f6c3-bf0a-417c-9f68-d83c62b54e32">
       <database-info product="MySQL" version="8.0.33" jdbc-version="4.2" driver-name="MySQL Connector/J" driver-version="mysql-connector-j-8.2.0 (Revision: 06a1f724497fd81c6a659131fda822c9e5085b6c)" dbms="MYSQL" exact-version="8.0.33" exact-driver-version="8.2">
         <extra-name-characters>#@</extra-name-characters>
@@ -15,7 +15,6 @@
       <database-info product="MySQL" version="8.4.5" jdbc-version="4.2" driver-name="MySQL Connector/J" driver-version="mysql-connector-j-8.2.0 (Revision: 06a1f724497fd81c6a659131fda822c9e5085b6c)" dbms="MYSQL" exact-version="8.4.5" exact-driver-version="8.2">
         <extra-name-characters>#@</extra-name-characters>
         <identifier-quote-string>`</identifier-quote-string>
-        <jdbc-catalog-is-schema>true</jdbc-catalog-is-schema>
       </database-info>
       <case-sensitivity plain-identifiers="lower" quoted-identifiers="lower" />
       <secret-storage>master_key</secret-storage>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -73,12 +73,7 @@
         </task>
         <projects_view>
           <tree_state>
-            <expand>
-              <path>
-                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
-                <item name="backend" type="f1a62948:ProjectNode" />
-              </path>
-            </expand>
+            <expand />
             <select />
           </tree_state>
         </projects_view>
@@ -102,18 +97,18 @@
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
-  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
-  "lastFilter": {
-    "state": "OPEN",
-    "assignee": "cocoaocean"
+  <component name="GitHubPullRequestSearchHistory">{
+  &quot;lastFilter&quot;: {
+    &quot;state&quot;: &quot;OPEN&quot;,
+    &quot;assignee&quot;: &quot;cocoaocean&quot;
   }
-}]]></component>
-  <component name="GithubPullRequestsUISettings"><![CDATA[{
-  "selectedUrlAndAccountId": {
-    "url": "https://github.com/FinPickTeam/FinPickTeam_BE.git",
-    "accountId": "e23dba73-0157-440e-83f9-43510870512b"
+}</component>
+  <component name="GithubPullRequestsUISettings">{
+  &quot;selectedUrlAndAccountId&quot;: {
+    &quot;url&quot;: &quot;https://github.com/FinPickTeam/FinPickTeam_BE.git&quot;,
+    &quot;accountId&quot;: &quot;e23dba73-0157-440e-83f9-43510870512b&quot;
   }
-}]]></component>
+}</component>
   <component name="LogFilters">
     <option name="FILTER_ERRORS" value="false" />
     <option name="FILTER_WARNINGS" value="false" />
@@ -144,6 +139,7 @@
     "Gradle.backend 빌드.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
+    "TomEE 서버.Tomcat 9.0.106.executor": "Run",
     "Tomcat Server.Tomcat 9.0.107.executor": "Run",
     "Tomcat 서버.Tomcat 9.0.105.executor": "Run",
     "Tomcat 서버.Tomcat 9.0.106.executor": "Run",
@@ -187,11 +183,11 @@
   <component name="RunDashboard">
     <option name="excludedTypes">
       <set>
-        <option value="#com.intellij.j2ee.web.tomcat.TomcatRunConfigurationFactory" />
+        <option value="TomeeConfiguration" />
       </set>
     </option>
   </component>
-  <component name="RunManager">
+  <component name="RunManager" selected="Tomcat 서버.Tomcat 9.0.106">
     <configuration default="true" type="JetRunConfigurationType">
       <module name="backend.main" />
       <method v="2">
@@ -205,8 +201,108 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
-    <configuration name="Tomcat 9.0.105" type="#com.intellij.j2ee.web.tomcat.TomcatRunConfigurationFactory" factoryName="Local" APPLICATION_SERVER_NAME="Tomcat 9.0.105" ALTERNATIVE_JRE_ENABLED="false" nameIsGenerated="true">
-      <option name="COMMON_VM_ARGUMENTS" value="-Dfile.encoding=UTF-8 -Dconsole.encoding=UTF-8" />
+    <configuration name="Tomcat 9.0.106" type="TomeeConfiguration" factoryName="Local" APPLICATION_SERVER_NAME="TomEE 9.0.106" ALTERNATIVE_JRE_ENABLED="false">
+      <option name="COMMON_VM_ARGUMENTS" value="-Dfile.encoding=UTF-8 -Dserver.port=8080 -Dcom.sun.management.jmxremote.authenticate=false -Duser.language=ko -Duser.region=KR " />
+      <option name="UPDATING_POLICY" value="restart-server" />
+      <deployment>
+        <artifact name="Gradle : org.scoula : backend-1.0-SNAPSHOT.war">
+          <settings>
+            <option name="CONTEXT_PATH" value="/" />
+          </settings>
+        </artifact>
+      </deployment>
+      <server-settings>
+        <option name="BASE_DIRECTORY_NAME" value="612263d2-53e5-49f7-b7b4-fe17f6984936" />
+      </server-settings>
+      <predefined_log_file enabled="true" id="Tomcat" />
+      <predefined_log_file enabled="true" id="Tomcat Catalina" />
+      <predefined_log_file id="Tomcat Manager" />
+      <predefined_log_file id="Tomcat Host Manager" />
+      <predefined_log_file id="Tomcat Localhost Access" />
+      <RunnerSettings RunnerId="Debug">
+        <option name="DEBUG_PORT" value="65205" />
+      </RunnerSettings>
+      <ConfigurationWrapper VM_VAR="JAVA_OPTS" RunnerId="Cover">
+        <option name="USE_ENV_VARIABLES" value="true" />
+        <STARTUP>
+          <option name="USE_DEFAULT" value="true" />
+          <option name="SCRIPT" value="" />
+          <option name="VM_PARAMETERS" value="" />
+          <option name="PROGRAM_PARAMETERS" value="" />
+        </STARTUP>
+        <SHUTDOWN>
+          <option name="USE_DEFAULT" value="true" />
+          <option name="SCRIPT" value="" />
+          <option name="VM_PARAMETERS" value="" />
+          <option name="PROGRAM_PARAMETERS" value="" />
+        </SHUTDOWN>
+      </ConfigurationWrapper>
+      <ConfigurationWrapper VM_VAR="JAVA_OPTS" RunnerId="Debug">
+        <option name="USE_ENV_VARIABLES" value="true" />
+        <STARTUP>
+          <option name="USE_DEFAULT" value="true" />
+          <option name="SCRIPT" value="" />
+          <option name="VM_PARAMETERS" value="" />
+          <option name="PROGRAM_PARAMETERS" value="" />
+        </STARTUP>
+        <SHUTDOWN>
+          <option name="USE_DEFAULT" value="true" />
+          <option name="SCRIPT" value="" />
+          <option name="VM_PARAMETERS" value="" />
+          <option name="PROGRAM_PARAMETERS" value="" />
+        </SHUTDOWN>
+      </ConfigurationWrapper>
+      <ConfigurationWrapper VM_VAR="JAVA_OPTS" RunnerId="Profile">
+        <option name="USE_ENV_VARIABLES" value="true" />
+        <STARTUP>
+          <option name="USE_DEFAULT" value="true" />
+          <option name="SCRIPT" value="" />
+          <option name="VM_PARAMETERS" value="" />
+          <option name="PROGRAM_PARAMETERS" value="" />
+        </STARTUP>
+        <SHUTDOWN>
+          <option name="USE_DEFAULT" value="true" />
+          <option name="SCRIPT" value="" />
+          <option name="VM_PARAMETERS" value="" />
+          <option name="PROGRAM_PARAMETERS" value="" />
+        </SHUTDOWN>
+      </ConfigurationWrapper>
+      <ConfigurationWrapper VM_VAR="JAVA_OPTS" RunnerId="Run">
+        <option name="USE_ENV_VARIABLES" value="true" />
+        <STARTUP>
+          <option name="USE_DEFAULT" value="true" />
+          <option name="SCRIPT" value="" />
+          <option name="VM_PARAMETERS" value="" />
+          <option name="PROGRAM_PARAMETERS" value="" />
+        </STARTUP>
+        <SHUTDOWN>
+          <option name="USE_DEFAULT" value="true" />
+          <option name="SCRIPT" value="" />
+          <option name="VM_PARAMETERS" value="" />
+          <option name="PROGRAM_PARAMETERS" value="" />
+        </SHUTDOWN>
+      </ConfigurationWrapper>
+      <method v="2">
+        <option name="Make" enabled="true" />
+        <option name="BuildArtifacts" enabled="true">
+          <artifact name="Gradle : org.scoula : backend-1.0-SNAPSHOT.war" />
+        </option>
+      </method>
+    </configuration>
+    <configuration default="true" type="TomeeConfiguration" factoryName="Local" ALTERNATIVE_JRE_ENABLED="false">
+      <deployment />
+      <server-settings />
+      <predefined_log_file enabled="true" id="Tomcat" />
+      <predefined_log_file enabled="true" id="Tomcat Catalina" />
+      <predefined_log_file id="Tomcat Manager" />
+      <predefined_log_file id="Tomcat Host Manager" />
+      <predefined_log_file id="Tomcat Localhost Access" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="Tomcat 9.0.106" type="#com.intellij.j2ee.web.tomcat.TomcatRunConfigurationFactory" factoryName="Local" APPLICATION_SERVER_NAME="Tomcat 9.0.106" ALTERNATIVE_JRE_ENABLED="false" nameIsGenerated="true">
+      <option name="COMMON_VM_ARGUMENTS" value="-Dfile.encoding=UTF-8 -Dconsole.encoding=UTF-8 -Dcom.sun.management.jmxremote.authenticate=false" />
       <option name="UPDATING_POLICY" value="restart-server" />
       <deployment>
         <artifact name="Gradle : org.scoula : backend-1.0-SNAPSHOT.war">
@@ -293,6 +389,10 @@
         </option>
       </method>
     </configuration>
+    <list>
+      <item itemvalue="Tomcat 서버.Tomcat 9.0.106" />
+      <item itemvalue="TomEE 서버.Tomcat 9.0.106" />
+    </list>
   </component>
   <component name="SharedIndexes">
     <attachedChunks>

--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -8,12 +8,14 @@ import org.scoula.challenge.enums.ChallengeType;
 import org.scoula.challenge.service.ChallengeService;
 import org.scoula.common.dto.CommonResponseDTO;
 import org.scoula.security.util.JwtUtil;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @Slf4j
+@Component
 @RestController
 @RequestMapping("/api/challenge")
 @RequiredArgsConstructor

--- a/src/main/java/org/scoula/challenge/controller/ChallengeSchedulerController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeSchedulerController.java
@@ -1,0 +1,22 @@
+package org.scoula.challenge.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.challenge.scheduler.ChallengeScheduler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.*;
+
+@Component
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenge")
+public class ChallengeSchedulerController {
+
+    private final ChallengeScheduler challengeScheduler;
+
+    // 🧪 수동으로 스케줄 실행해보기 (로컬 테스트용)
+    @GetMapping("/scheduler/run-now")
+    public String runNow() {
+        challengeScheduler.updateChallengeStatusesNow();
+        return "챌린지 상태 수동 업데이트 완료!";
+    }
+}

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -43,5 +43,11 @@ public interface ChallengeMapper {
     void updateChallengeStatus(@Param("challengeId") Long challengeId,
                                @Param("status") String status);
 
+    List<Challenge> findAllChallenges(); // 모든 챌린지
+
+    void completeUserChallenges(@Param("challengeId") Long challengeId); // 유저 챌린지 완료 처리
+
+    void markChallengeSuccess(@Param("challengeId") Long challengeId); // 유저 챌린지 성공 처리 (임시)
+
 }
 

--- a/src/main/java/org/scoula/challenge/scheduler/ChallengeScheduler.java
+++ b/src/main/java/org/scoula/challenge/scheduler/ChallengeScheduler.java
@@ -1,0 +1,70 @@
+package org.scoula.challenge.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.scoula.challenge.domain.Challenge;
+import org.scoula.challenge.enums.ChallengeStatus;
+import org.scoula.challenge.mapper.ChallengeMapper;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+//import javax.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeScheduler {
+
+    private final ChallengeMapper challengeMapper;
+
+    // 🚀 운영 시 실제 사용: 매일 새벽 3시
+    @Scheduled(cron = "0 0 3 * * *")
+    public void updateChallengeStatuses() {
+        processChallengeStatusUpdate("🕒 [자동 스케줄 실행]");
+    }
+
+    // ✅ 로컬에서 수동 호출용: 테스트할 수 있게 만든 메서드
+    public void updateChallengeStatusesNow() {
+        processChallengeStatusUpdate("🧪 [수동 호출 실행]");
+    }
+
+    // 🧪 개발 중엔 서버 켜질 때마다 실행도 가능 (원하면 주석 제거)
+    /*
+    @PostConstruct
+    public void initOnStartup() {
+        processChallengeStatusUpdate("🚀 [서버 기동시 초기 실행]");
+    }
+    */
+
+    private void processChallengeStatusUpdate(String mode) {
+        LocalDate today = LocalDate.now();
+        log.info("{} 챌린지 상태 업데이트 시작 - {}", mode, today);
+
+        List<Challenge> challenges = challengeMapper.findAllChallenges();
+
+        for (Challenge challenge : challenges) {
+            Long id = challenge.getId();
+            ChallengeStatus currentStatus = challenge.getStatus();
+            LocalDate startDate = challenge.getStartDate();
+            LocalDate endDate = challenge.getEndDate();
+
+            if (currentStatus != ChallengeStatus.IN_PROGRESS && today.isEqual(startDate)) {
+                challengeMapper.updateChallengeStatus(id, ChallengeStatus.IN_PROGRESS.name());
+                log.info("🔄 챌린지 시작 처리 - ID: {}", id);
+            }
+
+            if (currentStatus != ChallengeStatus.COMPLETED && today.isAfter(endDate)) {
+                challengeMapper.updateChallengeStatus(id, ChallengeStatus.COMPLETED.name());
+                log.info("✅ 챌린지 완료 처리 - ID: {}", id);
+
+                // 유저 챌린지도 완료 처리
+                challengeMapper.completeUserChallenges(id);
+                challengeMapper.markChallengeSuccess(id); // 임시 성공 처리
+            }
+        }
+
+        log.info("{} 챌린지 상태 업데이트 완료", mode);
+    }
+}

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -51,7 +51,8 @@ import javax.sql.DataSource;
         "org.scoula.news.service",
         "org.scoula.nhapi.service",
         "org.scoula.nhapi.util",
-        "org.scoula.challenge.service"
+        "org.scoula.challenge.service",
+        "org.scoula.challenge.scheduler",
 })
 @EnableTransactionManagement
 public class RootConfig {

--- a/src/main/java/org/scoula/config/SchedulerConfig.java
+++ b/src/main/java/org/scoula/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package org.scoula.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/org/scoula/config/WebConfig.java
+++ b/src/main/java/org/scoula/config/WebConfig.java
@@ -15,7 +15,7 @@ import javax.servlet.ServletRegistration;
 public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitializer {
     @Override
     protected Class<?>[] getRootConfigClasses() {
-        return new Class[] { RootConfig.class, SecurityConfig.class, RedisConfig.class };
+        return new Class[] { RootConfig.class, SecurityConfig.class, RedisConfig.class , SchedulerConfig.class};
     }
 
     @Override

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -89,5 +89,20 @@
         WHERE id = #{challengeId}
     </update>
 
+    <select id="findAllChallenges" resultType="org.scoula.challenge.domain.Challenge">
+        SELECT * FROM challenge
+    </select>
+
+    <update id="completeUserChallenges">
+        UPDATE user_challenge
+        SET is_completed = true, updated_at = NOW()
+        WHERE challenge_id = #{challengeId}
+    </update>
+
+    <update id="markChallengeSuccess">
+        UPDATE user_challenge
+        SET is_success = true
+        WHERE challenge_id = #{challengeId}
+    </update>
 
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
- 챌린지 상태 자동 변경 기능 스케줄링 추가
- 수동 상태 업데이트 테스트용 API 추가

## 📖 작업 내용 
- `ChallengeScheduler`: 매일 새벽 3시에 챌린지 상태를 자동으로 업데이트
  - 시작일이 오늘인 챌린지는 IN_PROGRESS로
  - 종료일이 지난 챌린지는 COMPLETED로 상태 전환
- `ChallengeSchedulerController`: 수동으로 스케줄 실행하는 GET API 추가 (`/api/challenge/scheduler/run-now`)
- `SchedulerConfig`: `@EnableScheduling` 추가
- `RootConfig`: `org.scoula.challenge.scheduler` 패키지 스캔 추가

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#123`)

## ✋ 질문 사항
-자동 스케쥴링 시간 의논 
- 스케쥴링 오류에 대한 코드는 아직 없음 -> 이 경우 처리 및 알림 주는 코드 필요 

## 🔗 관련 이슈
- closes #60 