### PR TITLE
feat: 회원가입 시 닉네임 및 레벨 자동 생성 기능 추가

### DIFF
--- a/.idea/artifacts/Gradle___org_scoula___backend_1_0_SNAPSHOT_war__exploded_.xml
+++ b/.idea/artifacts/Gradle___org_scoula___backend_1_0_SNAPSHOT_war__exploded_.xml
@@ -98,6 +98,13 @@
           <element id="library" level="project" name="Gradle: commons-collections:commons-collections:3.2.2" />
           <element id="library" level="project" name="Gradle: net.bytebuddy:byte-buddy:1.8.12" />
           <element id="library" level="project" name="Gradle: io.jsonwebtoken:jjwt-impl:0.11.5" />
+          <element id="library" level="project" name="Gradle: com.squareup.okhttp3:okhttp:4.12.0" />
+          <element id="library" level="project" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10" />
+          <element id="library" level="project" name="Gradle: com.squareup.okio:okio-jvm:3.6.0" />
+          <element id="library" level="project" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10" />
+          <element id="library" level="project" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.9.10" />
+          <element id="library" level="project" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:1.9.10" />
+          <element id="library" level="project" name="Gradle: org.jetbrains:annotations:13.0" />
         </element>
       </element>
     </root>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -127,49 +127,52 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Gradle.Build FinPickTeam_BE.executor": "Run",
-    "Gradle.Download Sources.executor": "Run",
-    "Gradle.FinPickTeam_BE [:clean].executor": "Run",
-    "Gradle.FinPickTeam_BE [build].executor": "Run",
-    "Gradle.FinPickTeam_BE [celan].executor": "Run",
-    "Gradle.FinPickTeam_BE [clean].executor": "Run",
-    "Gradle.FinPick_BE 빌드.executor": "Run",
-    "Gradle.backend 빌드.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "TomEE 서버.Tomcat 9.0.106.executor": "Run",
-    "Tomcat Server.Tomcat 9.0.107.executor": "Run",
-    "Tomcat 서버.Tomcat 9.0.105.executor": "Run",
-    "Tomcat 서버.Tomcat 9.0.106.executor": "Run",
-    "git-widget-placeholder": "refactor/#74-transactions-query",
-    "ignore.virus.scanning.warn.message": "true",
-    "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "C:/FinPick_BE/src/main/java/org/scoula/common/dto",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "project.structure.last.edited": "Project",
-    "project.structure.proportion": "0.0",
-    "project.structure.side.proportion": "0.0",
-    "settings.editor.selected.configurable": "preferences.pluginManager",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Gradle.Build FinPickTeam_BE.executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.Download Sources.executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.FinPickTeam_BE [:clean].executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.FinPickTeam_BE [build].executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.FinPickTeam_BE [celan].executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.FinPickTeam_BE [clean].executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.FinPick_BE 빌드.executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.backend 빌드.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;TomEE 서버.Tomcat 9.0.106.executor&quot;: &quot;Run&quot;,
+    &quot;Tomcat Server.Tomcat 9.0.107.executor&quot;: &quot;Run&quot;,
+    &quot;Tomcat 서버.Tomcat 9.0.105.executor&quot;: &quot;Run&quot;,
+    &quot;Tomcat 서버.Tomcat 9.0.106.executor&quot;: &quot;Run&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;refactor/#74-transactions-query&quot;,
+    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/FinPick_BE/src/main/java/org/scoula/common/dto&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.0&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   },
-  "keyToStringList": {
-    "DatabaseDriversLRU": [
-      "mysql"
+  &quot;keyToStringList&quot;: {
+    &quot;DatabaseDriversLRU&quot;: [
+      &quot;mysql&quot;
     ]
   }
-}]]></component>
+}</component>
   <component name="ReactorSettings">
     <option name="notificationShown" value="true" />
   </component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\FinPick_BE\src\main\java\org\scoula\common\dto" />
+    </key>
+    <key name="CopyClassDialog.RECENTS_KEY">
+      <recent name="org.scoula.user.domain" />
     </key>
   </component>
   <component name="RunAnythingCache">

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,10 @@ dependencies {
   // Jackson이 Java 8 날짜/시간 API를 인식하도록
   implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
+  // GPT 활용 관련 okhttp3 라이브러리 추가
+  implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+  implementation 'org.json:json:20240303'
+
 }
 
 // 정적 리소스 복사 작업 (최신 Gradle 스타일)

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -53,6 +53,7 @@ import javax.sql.DataSource;
         "org.scoula.nhapi.util",
         "org.scoula.challenge.service",
         "org.scoula.challenge.scheduler",
+        "org.scoula.user.util",
 })
 @EnableTransactionManagement
 public class RootConfig {

--- a/src/main/java/org/scoula/user/domain/UserStatus.java
+++ b/src/main/java/org/scoula/user/domain/UserStatus.java
@@ -1,0 +1,10 @@
+package org.scoula.user.domain;
+
+import lombok.Data;
+
+@Data
+public class UserStatus {
+    private Long id;
+    private String nickname;
+    private String level; // enum으로 저장
+}

--- a/src/main/java/org/scoula/user/dto/UserResponseDTO.java
+++ b/src/main/java/org/scoula/user/dto/UserResponseDTO.java
@@ -11,6 +11,7 @@ public class UserResponseDTO {
     private String email;
     private String userName;
     private String createdAt;
-
+    private String nickname;
+    private String level;
 }
 

--- a/src/main/java/org/scoula/user/enums/UserLevel.java
+++ b/src/main/java/org/scoula/user/enums/UserLevel.java
@@ -1,0 +1,18 @@
+package org.scoula.user.enums;
+
+public enum UserLevel {
+    SEEDLING("금융새싹"),
+    TRAINEE("금융견습"),
+    WIZARD("금융법사"),
+    MASTER("금융도사");
+
+    private final String label;
+
+    UserLevel(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/org/scoula/user/exception/signup/NicknameGenerationException.java
+++ b/src/main/java/org/scoula/user/exception/signup/NicknameGenerationException.java
@@ -1,0 +1,9 @@
+package org.scoula.user.exception.signup;
+
+import org.scoula.common.exception.BaseException;
+
+public class NicknameGenerationException extends BaseException {
+    public NicknameGenerationException() {
+        super("닉네임 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", 500);
+    }
+}

--- a/src/main/java/org/scoula/user/mapper/UserStatusMapper.java
+++ b/src/main/java/org/scoula/user/mapper/UserStatusMapper.java
@@ -1,0 +1,10 @@
+package org.scoula.user.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.scoula.user.domain.UserStatus;
+
+@Mapper
+public interface UserStatusMapper {
+    void save(UserStatus status);
+    boolean isNicknameDuplicated(String nickname);
+}

--- a/src/main/java/org/scoula/user/util/NicknameGenerator.java
+++ b/src/main/java/org/scoula/user/util/NicknameGenerator.java
@@ -1,0 +1,81 @@
+package org.scoula.user.util;
+
+import okhttp3.*;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.UUID;
+
+@Component
+public class NicknameGenerator {
+
+    private static final Logger log = LoggerFactory.getLogger(NicknameGenerator.class);
+
+    @Value("${gpt.api.key}")
+    private String apiKey;
+
+    private final String[] fallbackVerbs = {"코딩하는", "주식하는", "청약하는", "절약하는", "분석하는"};
+    private final String[] fallbackNouns = {"토끼", "부엉이", "호랑이", "모몽가", "너구리", "펭귄", "도치", "햄스터"};
+    private final Random random = new Random();
+
+    public String generateNickname() {
+        try {
+            OkHttpClient client = new OkHttpClient();
+
+            String prompt = "랜덤한 {동사}하는{동물 또는 캐릭터} 형태의 한국어 닉네임을 한 개만 출력해줘. 예: '코딩하는토끼'";
+            JSONObject requestBody = new JSONObject()
+                    .put("model", "gpt-4o")  // 또는 gpt-4o-mini
+                    .put("messages", new org.json.JSONArray()
+                            .put(new JSONObject()
+                                    .put("role", "user")
+                                    .put("content", prompt)))
+                    .put("temperature", 0.9);
+
+            log.info("🟡 GPT 닉네임 생성 요청 시작");
+
+            Request request = new Request.Builder()
+                    .url("https://api.openai.com/v1/chat/completions")
+                    .addHeader("Authorization", "Bearer " + apiKey)
+                    .addHeader("Content-Type", "application/json")
+                    .post(RequestBody.create(requestBody.toString(), MediaType.parse("application/json")))
+                    .build();
+
+            Response response = client.newCall(request).execute();
+
+            if (!response.isSuccessful()) {
+                log.warn("🔴 GPT 응답 실패 - status: {}", response.code());
+                throw new IOException("GPT API 응답 실패: " + response.code());
+            }
+
+            String body = response.body().string();
+            log.debug("🟢 GPT 응답 원본: {}", body);
+
+            JSONObject responseBody = new JSONObject(body);
+            String result = responseBody.getJSONArray("choices")
+                    .getJSONObject(0)
+                    .getJSONObject("message")
+                    .getString("content");
+
+            String cleaned = result.replaceAll("[^가-힣a-zA-Z0-9]", "").trim();
+            log.info("🟢 GPT 닉네임 생성 성공: {}", cleaned);
+            return cleaned;
+
+        } catch (IOException e) {
+            log.error("🔻 GPT 호출 실패 - fallback 닉네임 생성으로 대체: {}", e.getMessage());
+            return generateFallbackNickname();
+        }
+    }
+
+    private String generateFallbackNickname() {
+        String verb = fallbackVerbs[random.nextInt(fallbackVerbs.length)];
+        String noun = fallbackNouns[random.nextInt(fallbackNouns.length)];
+        String fallback = verb + noun + UUID.randomUUID().toString().substring(0, 3);
+        log.info("🪃 fallback 닉네임 생성: {}", fallback);
+        return fallback;
+    }
+}

--- a/src/main/resources/org/scoula/user/mapper/UserStatusMapper.xml
+++ b/src/main/resources/org/scoula/user/mapper/UserStatusMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.scoula.user.mapper.UserStatusMapper">
+
+    <insert id="save" parameterType="org.scoula.user.domain.UserStatus">
+        INSERT INTO user_status (id, nickname, level)
+        VALUES (#{id}, #{nickname}, #{level})
+    </insert>
+
+    <select id="isNicknameDuplicated" resultType="boolean">
+        SELECT EXISTS(SELECT 1 FROM user_status WHERE nickname = #{nickname})
+    </select>
+
+</mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
- 회원가입 시 닉네임 자동 생성 및 초기 레벨 설정 기능 구현

## 📖 작업 내용 
- GPT API를 활용해 '{동사}하는{동물}' 형태의 랜덤 닉네임 생성
- 생성된 닉네임 중복 검사 후 user_status 테이블에 저장
- 초기 레벨 "금융새싹" 저장
- GPT 호출 실패 시 fallback 닉네임 생성 로직 구현
- UserResponseDTO에 nickname, level 필드 추가

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [x] 문서화가 필요한 경우 추가했습니다.

## ✋ 질문 사항
- 

## 🔗 관련 이슈
- closes #76 
