### PR TITLE
Feat/#94 challenge home api

### DIFF
--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -72,5 +72,14 @@ public class ChallengeController {
         return CommonResponseDTO.success("챌린지 참여 신청이 완료되었습니다.");
     }
 
+    @GetMapping("/summary")
+    public CommonResponseDTO<ChallengeSummaryResponseDTO> getChallengeSummary(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+
+        ChallengeSummaryResponseDTO summary = challengeService.getChallengeSummary(userId);
+        return CommonResponseDTO.success("챌린지 요약 정보 조회 성공", summary);
+    }
+
 
 }

--- a/src/main/java/org/scoula/challenge/dto/ChallengeSummaryResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeSummaryResponseDTO.java
@@ -3,10 +3,12 @@ package org.scoula.challenge.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class ChallengeSummaryResponseDTO {
     private int totalChallenges;
     private int successCount;

--- a/src/main/java/org/scoula/challenge/dto/ChallengeSummaryResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeSummaryResponseDTO.java
@@ -1,0 +1,14 @@
+package org.scoula.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ChallengeSummaryResponseDTO {
+    private int totalChallenges;
+    private int successCount;
+    private double achievementRate;
+}

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -64,5 +64,12 @@ public interface ChallengeMapper {
 
     ChallengeSummaryResponseDTO getChallengeSummary(@Param("userId") Long userId);
 
+    // 유저별 참여 횟수, 성공률 등 계산하는 메서드
+    void insertOrUpdateUserChallengeSummary(@Param("userId") Long userId);
+    void incrementUserSuccessCount(@Param("userId") Long userId);
+    void incrementUserTotalChallenges(@Param("userId") Long userId);
+    void updateAchievementRate(@Param("userId") Long userId);
+
+
 }
 

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -4,6 +4,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.scoula.challenge.domain.Challenge;
 import org.scoula.challenge.dto.ChallengeMemberDTO;
+import org.scoula.challenge.dto.ChallengeSummaryResponseDTO;
 import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
 
@@ -61,6 +62,7 @@ public interface ChallengeMapper {
 
     String getCategoryNameById(@Param("categoryId") Long categoryId);
 
+    ChallengeSummaryResponseDTO getChallengeSummary(@Param("userId") Long userId);
 
 }
 

--- a/src/main/java/org/scoula/challenge/scheduler/ChallengeScheduler.java
+++ b/src/main/java/org/scoula/challenge/scheduler/ChallengeScheduler.java
@@ -110,7 +110,13 @@ public class ChallengeScheduler {
                     // 성공 처리
                     challengeMapper.succeedUserChallenge(userId, challenge.getId());
                     log.info("🎉 성공 처리 - 유저ID: {}, 챌린지ID: {}", userId, challenge.getId());
+
+                    // ✅ 성공 횟수 +1 및 성공률 갱신
+                    challengeMapper.insertOrUpdateUserChallengeSummary(userId);
+                    challengeMapper.incrementUserSuccessCount(userId);
+                    challengeMapper.updateAchievementRate(userId);
                 }
+
             }
         }
 

--- a/src/main/java/org/scoula/challenge/service/ChallengeService.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeService.java
@@ -1,9 +1,6 @@
 package org.scoula.challenge.service;
 
-import org.scoula.challenge.dto.ChallengeCreateRequestDTO;
-import org.scoula.challenge.dto.ChallengeCreateResponseDTO;
-import org.scoula.challenge.dto.ChallengeDetailResponseDTO;
-import org.scoula.challenge.dto.ChallengeListResponseDTO;
+import org.scoula.challenge.dto.*;
 import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
 
@@ -14,5 +11,6 @@ public interface ChallengeService {
     List<ChallengeListResponseDTO> getChallenges(Long userId, ChallengeType type, ChallengeStatus status);
     ChallengeDetailResponseDTO getChallengeDetail(Long userId, Long challengeId);
     void joinChallenge(Long userId, Long challengeId, Integer password);
+    ChallengeSummaryResponseDTO getChallengeSummary(Long userId);
 
 }

--- a/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
@@ -86,6 +86,12 @@ public class ChallengeServiceImpl implements ChallengeService {
         // 7. 닉네임 조회
         String nickname = userMapper.findNicknameById(userId);
 
+        // 8. 참여관련 숫자 데이터 수정
+        // 요약 테이블이 없을 수도 있으니 insert or update
+        challengeMapper.insertOrUpdateUserChallengeSummary(userId);
+        challengeMapper.incrementUserTotalChallenges(userId);
+        challengeMapper.updateAchievementRate(userId);
+
         return new ChallengeCreateResponseDTO(challenge.getId(), nickname);
     }
 

--- a/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
@@ -206,6 +206,10 @@ public class ChallengeServiceImpl implements ChallengeService {
         }
     }
 
+    @Override
+    public ChallengeSummaryResponseDTO getChallengeSummary(Long userId) {
+        return challengeMapper.getChallengeSummary(userId);
+    }
 
 
 }

--- a/src/main/java/org/scoula/user/mapper/UserMapper.java
+++ b/src/main/java/org/scoula/user/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package org.scoula.user.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.scoula.user.domain.User;
 
 @Mapper
@@ -11,4 +12,6 @@ public interface UserMapper {
     User findByEmail(String email); // 이메일로 비밀번호 찾기
     String findNicknameById(Long id);
     void updatePassword(User user); // 비밀번호 재발급
+    void insertUserChallengeSummary(@Param("userId") Long userId);
+
 }

--- a/src/main/java/org/scoula/user/service/UserServiceImpl.java
+++ b/src/main/java/org/scoula/user/service/UserServiceImpl.java
@@ -67,7 +67,7 @@ public class UserServiceImpl implements UserService {
         user.setLastPwChangeAt(LocalDateTime.now());
 
         try {
-            userMapper.save(user);
+            userMapper.save(user); // 1. 유저 저장
         } catch (DuplicateKeyException e) {
             log.warn("❌ DB 이메일 중복 에러 발생: {}", user.getEmail());
             throw new DuplicateEmailException();
@@ -84,7 +84,8 @@ public class UserServiceImpl implements UserService {
         status.setId(user.getId());
         status.setNickname(nickname);
         status.setLevel(UserLevel.SEEDLING.getLabel()); // → "금융새싹"
-        userStatusMapper.save(status);
+        userStatusMapper.save(status); // 2. 상태 저장
+        userMapper.insertUserChallengeSummary(user.getId()); // 3. 챌린지 요약 0으로 초기화
 
         return UserResponseDTO.builder()
                 .id(user.getId())

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -125,5 +125,14 @@
         SELECT name FROM challenge_category WHERE id = #{categoryId}
     </select>
 
+    <select id="getChallengeSummary" resultType="org.scoula.challenge.dto.ChallengeSummaryResponseDTO">
+        SELECT
+            total_challenges AS totalChallenges,
+            success_count AS successCount,
+            achievement_rate AS achievementRate
+        FROM user_challenge_summary
+        WHERE id = #{userId}
+    </select>
+
 
 </mapper>

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -134,5 +134,29 @@
         WHERE id = #{userId}
     </select>
 
+    <insert id="insertOrUpdateUserChallengeSummary">
+        INSERT INTO user_challenge_summary (id, total_challenges, success_count, achievement_rate)
+        VALUES (#{userId}, 0, 0, 0.00)
+            ON DUPLICATE KEY UPDATE id = id
+    </insert>
+
+    <update id="incrementUserTotalChallenges">
+        UPDATE user_challenge_summary
+        SET total_challenges = total_challenges + 1
+        WHERE id = #{userId}
+    </update>
+
+    <update id="incrementUserSuccessCount">
+        UPDATE user_challenge_summary
+        SET success_count = success_count + 1
+        WHERE id = #{userId}
+    </update>
+
+    <update id="updateAchievementRate">
+        UPDATE user_challenge_summary
+        SET achievement_rate = ROUND(success_count * 100.0 / total_challenges, 2)
+        WHERE id = #{userId} AND total_challenges > 0
+    </update>
+
 
 </mapper>

--- a/src/main/resources/org/scoula/user/mapper/UserMapper.xml
+++ b/src/main/resources/org/scoula/user/mapper/UserMapper.xml
@@ -29,4 +29,9 @@
         WHERE email = #{email}
     </update>
 
+    <insert id="insertUserChallengeSummary">
+        INSERT INTO user_challenge_summary (id, total_challenges, success_count, achievement_rate)
+        VALUES (#{userId}, 0, 0, 0.00)
+    </insert>
+
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
챌린지 홈 요약 정보(총 참여 횟수, 성공 횟수, 성공률) 제공을 위한 전체 기능 구현  
유저 가입 → 챌린지 생성 → 스케줄러 성공 처리 흐름까지 누적값 관리 포함  
MyBatis와 DTO 간의 타입 오류 해결 포함

## 📖 작업 내용 
- 유저 회원가입시 `user_challenge_summary` 테이블에 해당 유저 초기값 (0, 0, 0.00) 삽입
- 챌린지 생성 시 total_challenges 값 +1
- 챌린지 성공 처리 시 success_count 값 +1, 성공률(%) 계산
- API `/api/challenge/summary` 구현 → 총 횟수/성공횟수/성공률 응답
- 관련 Mapper SQL 및 DTO 작성
- DTO 생성자 오류 수정 → @NoArgsConstructor 적용으로 매핑 문제 해결

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [x] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항
- 성공률 소수점 두 자리까지 반올림하는 방식은 이대로 유지해도 괜찮을까요?

## 🔗 관련 이슈
Closes #94 
