### PR TITLE
feat: 거래내역 카테고리/메모 수정 기능 추가

### DIFF
--- a/src/main/java/org/scoula/transactions/controller/LedgerController.java
+++ b/src/main/java/org/scoula/transactions/controller/LedgerController.java
@@ -3,8 +3,11 @@ package org.scoula.transactions.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.scoula.transactions.dto.LedgerCategoryUpdateDto;
 import org.scoula.transactions.dto.LedgerDetailDto;
 import org.scoula.transactions.dto.LedgerDto;
+import org.scoula.transactions.dto.LedgerMemoUpdateDto;
+import org.scoula.transactions.service.LedgerEditService;
 import org.scoula.transactions.service.LedgerService;
 import org.scoula.common.dto.CommonResponseDTO;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +21,7 @@ import java.util.List;
 public class LedgerController {
 
     private final LedgerService ledgerService;
+    private final LedgerEditService ledgerEditService;
 
     @ApiOperation("통합 거래내역 조회 (카테고리, 기간 필터 지원)")
     @GetMapping
@@ -39,4 +43,25 @@ public class LedgerController {
         LedgerDetailDto result = ledgerService.getLedgerDetail(userId, ledgerId);
         return CommonResponseDTO.success("거래 상세 조회 성공", result);
     }
+
+    @ApiOperation("거래 카테고리 수정")
+    @PatchMapping("/{ledgerId}/category")
+    public CommonResponseDTO<Void> updateLedgerCategory(
+            @PathVariable Long userId,
+            @PathVariable Long ledgerId,
+            @RequestBody LedgerCategoryUpdateDto dto) {
+        ledgerEditService.updateCategory(ledgerId, dto.getCategoryId());
+        return CommonResponseDTO.success("카테고리 수정 완료", null);
+    }
+
+    @ApiOperation("거래 메모 수정")
+    @PatchMapping("/{ledgerId}/memo")
+    public CommonResponseDTO<Void> updateLedgerMemo(
+            @PathVariable Long userId,
+            @PathVariable Long ledgerId,
+            @RequestBody LedgerMemoUpdateDto dto) {
+        ledgerEditService.updateMemo(ledgerId, dto.getMemo());
+        return CommonResponseDTO.success("메모 수정 완료", null);
+    }
+
 }

--- a/src/main/java/org/scoula/transactions/dto/LedgerCategoryUpdateDto.java
+++ b/src/main/java/org/scoula/transactions/dto/LedgerCategoryUpdateDto.java
@@ -1,0 +1,9 @@
+// LedgerCategoryUpdateDto.java
+package org.scoula.transactions.dto;
+
+import lombok.Data;
+
+@Data
+public class LedgerCategoryUpdateDto {
+    private Long categoryId;
+}

--- a/src/main/java/org/scoula/transactions/dto/LedgerMemoUpdateDto.java
+++ b/src/main/java/org/scoula/transactions/dto/LedgerMemoUpdateDto.java
@@ -1,0 +1,9 @@
+package org.scoula.transactions.dto;
+
+import lombok.Data;
+
+@Data
+public class LedgerMemoUpdateDto {
+    private String memo;
+}
+

--- a/src/main/java/org/scoula/transactions/mapper/LedgerMapper.java
+++ b/src/main/java/org/scoula/transactions/mapper/LedgerMapper.java
@@ -14,7 +14,12 @@ public interface LedgerMapper {
                              @Param("category") String category);
 
     Ledger findLedgerDetail(@Param("userId") Long userId, @Param("ledgerId") Long ledgerId);
+
     void accountInsert(Ledger ledger);
     void cardInsert(Ledger ledger);
+
+    void updateLedgerCategory(@Param("ledgerId") Long ledgerId, @Param("categoryId") Long categoryId);
+    void updateLedgerMemo(@Param("ledgerId") Long ledgerId, @Param("memo") String memo);
+
 }
 

--- a/src/main/java/org/scoula/transactions/service/LedgerEditService.java
+++ b/src/main/java/org/scoula/transactions/service/LedgerEditService.java
@@ -1,0 +1,20 @@
+package org.scoula.transactions.service;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.transactions.mapper.LedgerMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LedgerEditService {
+
+    private final LedgerMapper ledgerMapper;
+
+    public void updateCategory(Long ledgerId, Long categoryId) {
+        ledgerMapper.updateLedgerCategory(ledgerId, categoryId);
+    }
+
+    public void updateMemo(Long ledgerId, String memo) {
+        ledgerMapper.updateLedgerMemo(ledgerId, memo);
+    }
+}

--- a/src/main/resources/org/scoula/transactions/mapper/LedgerMapper.xml
+++ b/src/main/resources/org/scoula/transactions/mapper/LedgerMapper.xml
@@ -58,4 +58,17 @@
                  )
     </insert>
 
+    <update id="updateLedgerCategory">
+        UPDATE ledger
+        SET category_id = #{categoryId}
+        WHERE id = #{ledgerId}
+    </update>
+
+    <update id="updateLedgerMemo">
+        UPDATE ledger
+        SET memo = #{memo}
+        WHERE id = #{ledgerId}
+    </update>
+
+
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
가계부 항목 편집 기능 구현 (거래내역의 카테고리 및 메모 수정 API 추가)

## 📖 작업 내용 

- [ ] `/api/users/{userId}/ledger/{ledgerId}/category`
→ 카테고리 수정 PATCH API 구현

- [ ] `/api/users/{userId}/ledger/{ledgerId}/memo`
→ 메모 등록/수정 PATCH API 구현

Swagger 문서 테스트 및 응답 확인 완료

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
closes #103 
