### PR TITLE
feat: 챌린지 결과 조회 및 확인 관련 API 구현

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -154,6 +154,7 @@ CREATE TABLE `coin` (
                         FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE
 );
 ALTER TABLE `coin` MODIFY COLUMN `amount` BIGINT NOT NULL;
+ALTER TABLE coin ADD COLUMN monthly_cumulative_amount BIGINT NOT NULL DEFAULT 0;
 
 -- 13. 재화내역
 DROP TABLE IF EXISTS `coin_history`;
@@ -168,6 +169,10 @@ CREATE TABLE `coin_history` (
                                 PRIMARY KEY (`id`),
                                 FOREIGN KEY (`user_id`) REFERENCES `coin`(`id`) ON DELETE CASCADE
 );
+ALTER TABLE coin_history DROP COLUMN comment;
+ALTER TABLE coin_history
+    ADD COLUMN coin_type ENUM('QUIZ', 'CHALLENGE', 'AVATAR', 'GIFTICON') NOT NULL;
+
 
 -- 14. 알람내역
 DROP TABLE IF EXISTS `ALARMS`;
@@ -460,6 +465,8 @@ CREATE TABLE `challenge` (
 ALTER TABLE challenge ADD use_password BOOLEAN DEFAULT FALSE;
 ALTER TABLE challenge ADD COLUMN participant_count INT DEFAULT 0;
 
+ALTER TABLE challenge ADD COLUMN reward_point INT NOT NULL;
+
 
 -- 3. 유저-챌린지 매핑 (참여 내역)
 DROP TABLE IF EXISTS `user_challenge`;
@@ -479,6 +486,9 @@ CREATE TABLE `user_challenge` (
 );
 
 ALTER TABLE user_challenge CHANGE joined_at created_at DATETIME DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE user_challenge ADD COLUMN result_checked TINYINT(1) DEFAULT 0;
+ALTER TABLE user_challenge ADD COLUMN actual_reward_point INT DEFAULT 0;
 
 
 -- 4. 챌린지 진행 통계 (유저별 집계)

--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -81,5 +81,31 @@ public class ChallengeController {
         return CommonResponseDTO.success("챌린지 요약 정보 조회 성공", summary);
     }
 
+    @GetMapping("/{id}/result")
+    public CommonResponseDTO<ChallengeResultResponseDTO> getChallengeResult(@PathVariable("id") Long challengeId,
+                                                                            HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+        ChallengeResultResponseDTO result = challengeService.getChallengeResult(userId, challengeId);
+        return CommonResponseDTO.success("챌린지 결과 조회 성공", result);
+    }
+
+    @PatchMapping("/{id}/result/confirm")
+    public CommonResponseDTO<?> confirmChallengeResult(@PathVariable("id") Long challengeId,
+                                                       HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+        challengeService.confirmChallengeResult(userId, challengeId);
+        return CommonResponseDTO.success("챌린지 결과 확인 처리 완료");
+    }
+
+    @GetMapping("/has-unconfirmed")
+    public CommonResponseDTO<Boolean> hasUnconfirmedChallengeResult(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+        boolean result = challengeService.hasUnconfirmedResult(userId);
+        return CommonResponseDTO.success("미확인 결과 존재 여부 확인", result);
+    }
+
 
 }

--- a/src/main/java/org/scoula/challenge/dto/ChallengeResultResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeResultResponseDTO.java
@@ -1,0 +1,13 @@
+package org.scoula.challenge.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ChallengeResultResponseDTO {
+    private String resultType; // SUCCESS_WIN, SUCCESS_EQUAL, FAIL
+    private Integer actualRewardPoint;
+    private Integer savedAmount; // 절약 금액 (goal_value - actual_value)
+    private Object stockRecommendation; // 추천 주식 응답 (나중에 객체 교체 예정)
+}

--- a/src/main/java/org/scoula/challenge/enums/ChallengeResultType.java
+++ b/src/main/java/org/scoula/challenge/enums/ChallengeResultType.java
@@ -1,0 +1,5 @@
+package org.scoula.challenge.enums;
+
+public enum ChallengeResultType {
+    SUCCESS_WIN, SUCCESS_EQUAL, FAIL
+}

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -70,5 +70,12 @@ public interface ChallengeMapper {
     void updateAchievementRate(@Param("userId") Long userId);
 
 
+    // 챌린지 결과 확인 관련 메서드
+    int getActualValue(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
+    int getActualRewardPoint(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
+    void markResultChecked(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
+    boolean existsUnconfirmedCompletedChallenge(@Param("userId") Long userId);
+
+
 }
 

--- a/src/main/java/org/scoula/challenge/service/ChallengeService.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeService.java
@@ -13,4 +13,8 @@ public interface ChallengeService {
     void joinChallenge(Long userId, Long challengeId, Integer password);
     ChallengeSummaryResponseDTO getChallengeSummary(Long userId);
 
+    ChallengeResultResponseDTO getChallengeResult(Long userId, Long challengeId);
+    void confirmChallengeResult(Long userId, Long challengeId);
+    boolean hasUnconfirmedResult(Long userId);
+
 }

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -158,5 +158,31 @@
         WHERE id = #{userId} AND total_challenges > 0
     </update>
 
+    <select id="getActualValue" resultType="int">
+        SELECT actual_value FROM user_challenge
+        WHERE user_id = #{userId} AND challenge_id = #{challengeId}
+    </select>
+
+    <select id="getActualRewardPoint" resultType="int">
+        SELECT actual_reward_point FROM user_challenge
+        WHERE user_id = #{userId} AND challenge_id = #{challengeId}
+    </select>
+
+    <update id="markResultChecked">
+        UPDATE user_challenge
+        SET result_checked = 1
+        WHERE user_id = #{userId} AND challenge_id = #{challengeId}
+    </update>
+
+    <select id="existsUnconfirmedCompletedChallenge" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1 FROM user_challenge uc
+                              JOIN challenge c ON uc.challenge_id = c.id
+            WHERE uc.user_id = #{userId}
+              AND uc.result_checked = 0
+              AND c.status = 'COMPLETED'
+        )
+    </select>
+
 
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
챌린지 결과 확인 기능을 위한 API 3종을 구현하고 챌린지 상세 조회 흐름에 반영하였습니다.

## 📖 작업 내용 
- 챌린지 결과 데이터 조회 API (`GET /api/challenge/{id}/result`)
- 챌린지 결과 확인 처리 API (`PATCH /api/challenge/{id}/result/confirm`)
- 결과 미확인 챌린지 존재 여부 확인 API (`GET /api/challenge/has-unconfirmed`)
- DTO 및 Mapper, 서비스, 컨트롤러 계층까지 로직 구현 완료

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. 

## ✋ 질문 사항
- 포인트 지급 및 주식 추천 데이터는 별도 API 또는 confirm 시점에서 연동 예정

## 🔗 관련 이슈
- closes #93 
