### PR TITLE
feat: 계좌/카드 개별 삭제 기능 추가

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -199,6 +199,7 @@ CREATE TABLE `account` (
                            `product_name` VARCHAR(255) NOT NULL,
                            `account_type` VARCHAR(50) NOT NULL,
                            `balance` DECIMAL(20,2) NOT NULL,
+                           `is_active` BOOLEAN DEFAULT TRUE,
                            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                            PRIMARY KEY (`id`),
                            FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE
@@ -235,6 +236,7 @@ CREATE TABLE `card` (
                         `card_maskednum` VARCHAR(30) NOT NULL,
                         `card_member_type` ENUM('SELF', 'FAMILY') NOT NULL,
                         `card_type` ENUM('CREDIT', 'DEBIT') NOT NULL,
+                        `is_active` BOOLEAN DEFAULT TRUE,
                         `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                         PRIMARY KEY (`id`),
                         FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE

--- a/src/main/java/org/scoula/account/controller/AccountController.java
+++ b/src/main/java/org/scoula/account/controller/AccountController.java
@@ -40,4 +40,14 @@ public class AccountController {
         return ResponseEntity.ok(CommonResponseDTO.success("사용자 전체 계좌 동기화 성공", null));
     }
 
+    @DeleteMapping("/{accountId}")
+    public ResponseEntity<CommonResponseDTO<Void>> deleteAccount(
+            @PathVariable Long accountId,
+            @RequestParam Long userId //TODO 나중에 @AuthenticationPrincipal로 바꾸기
+    ) {
+        accountService.deactivateAccount(accountId, userId);
+        return ResponseEntity.ok(CommonResponseDTO.success("계좌 비활성화 완료"));
+    }
+
+
 }

--- a/src/main/java/org/scoula/account/domain/Account.java
+++ b/src/main/java/org/scoula/account/domain/Account.java
@@ -22,5 +22,6 @@ public class Account {
     private String productName;        // 상품명
     private String accountType;        // DEPOSIT / SAVINGS 등
     private BigDecimal balance;        // 현재 잔액
+    private Boolean isActive;
     private LocalDateTime createdAt;   // 생성일시 (DB default now())
 }

--- a/src/main/java/org/scoula/account/mapper/AccountMapper.java
+++ b/src/main/java/org/scoula/account/mapper/AccountMapper.java
@@ -12,15 +12,13 @@ import java.util.List;
 public interface AccountMapper {
 
     void insert(Account account);
-
     void updateBalanceByUser(
             @Param("userId") Long userId,
             @Param("pinAccountNumber") String pinAccountNumber,
             @Param("balance") BigDecimal balance
     );
-
     Account findById(Long accountId);// 핀어카운트로 계좌 조회
-
     List<Account> findByUserId(Long userId);
+    void updateIsActive(@Param("id") Long id, @Param("isActive") boolean isActive);
 
 }

--- a/src/main/java/org/scoula/account/service/AccountService.java
+++ b/src/main/java/org/scoula/account/service/AccountService.java
@@ -7,4 +7,5 @@ public interface AccountService {
     AccountRegisterResponseDto registerFinAccount(FinAccountRequestDto dto);
     void syncAccountById(Long accountId);
     void syncAllAccountsByUserId(Long userId);
+    void deactivateAccount(Long accountId, Long userId);
 }

--- a/src/main/java/org/scoula/account/service/AccountServiceImpl.java
+++ b/src/main/java/org/scoula/account/service/AccountServiceImpl.java
@@ -6,6 +6,7 @@ import org.scoula.account.domain.Account;
 import org.scoula.account.dto.AccountRegisterResponseDto;
 import org.scoula.account.mapper.AccountMapper;
 import org.scoula.common.exception.BaseException;
+import org.scoula.common.exception.ForbiddenException;
 import org.scoula.nhapi.dto.FinAccountRequestDto;
 import org.scoula.nhapi.service.NhAccountService;
 import org.scoula.transactions.service.AccountTransactionService;
@@ -81,5 +82,18 @@ public class AccountServiceImpl implements AccountService {
         }
     }
 
+    @Override
+    public void deactivateAccount(Long accountId, Long userId) {
+        Account account = accountMapper.findById(accountId);
 
+        if (account == null || !account.getUserId().equals(userId)) {
+            throw new ForbiddenException("본인 계좌만 삭제할 수 있습니다");
+        }
+
+        if (!Boolean.TRUE.equals(account.getIsActive())) {
+            return; // 이미 비활성화면 그냥 무시
+        }
+
+        accountMapper.updateIsActive(accountId, false);
+    }
 }

--- a/src/main/java/org/scoula/card/controller/CardController.java
+++ b/src/main/java/org/scoula/card/controller/CardController.java
@@ -32,4 +32,14 @@ public class CardController {
         cardService.syncAllCardsByUserId(userId);
         return ResponseEntity.ok(CommonResponseDTO.success("사용자의 모든 카드 승인내역 동기화 완료"));
     }
+
+    @DeleteMapping("/{cardId}")
+    public ResponseEntity<CommonResponseDTO<Void>> deleteCard(
+            @PathVariable Long cardId,
+            @RequestParam Long userId //TODO 나중에 @AuthenticationPrincipal로 바꾸기
+    ) {
+        cardService.deactivateCard(cardId, userId);
+        return ResponseEntity.ok(CommonResponseDTO.success("카드 비활성화 완료"));
+    }
+
 }

--- a/src/main/java/org/scoula/card/domain/Card.java
+++ b/src/main/java/org/scoula/card/domain/Card.java
@@ -19,4 +19,5 @@ public class Card {
     private String cardMaskednum;
     private String cardMemberType;
     private String cardType;
+    private Boolean isActive;
 }

--- a/src/main/java/org/scoula/card/mapper/CardMapper.java
+++ b/src/main/java/org/scoula/card/mapper/CardMapper.java
@@ -1,6 +1,7 @@
 package org.scoula.card.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.scoula.card.domain.Card;
 
 import java.util.List;
@@ -10,4 +11,5 @@ public interface CardMapper {
     void insertCard(Card card);
     Card findById(Long cardId);
     List<Card> findByUserId(Long userId);
+    void updateIsActive(@Param("id") Long id, @Param("isActive") boolean isActive);
 }

--- a/src/main/java/org/scoula/card/service/CardService.java
+++ b/src/main/java/org/scoula/card/service/CardService.java
@@ -7,4 +7,5 @@ public interface CardService {
     CardRegisterResponseDto registerCard(FinCardRequestDto dto);
     void syncCardById(Long cardId);
     void syncAllCardsByUserId(Long userId);
+    void deactivateCard(Long cardId, Long userId);
 }

--- a/src/main/java/org/scoula/card/service/CardServiceImpl.java
+++ b/src/main/java/org/scoula/card/service/CardServiceImpl.java
@@ -6,6 +6,7 @@ import org.json.JSONObject;
 import org.scoula.card.domain.Card;
 import org.scoula.card.dto.CardRegisterResponseDto;
 import org.scoula.common.exception.BaseException;
+import org.scoula.common.exception.ForbiddenException;
 import org.scoula.nhapi.dto.FinCardRequestDto;
 import org.scoula.card.mapper.CardMapper;
 import org.scoula.nhapi.client.NHApiClient;
@@ -97,4 +98,19 @@ public class CardServiceImpl implements CardService {
             log.info("✅ 카드 동기화 완료: cardId={}, userId={}", card.getId(), userId);
         }
     }
+    @Override
+    public void deactivateCard(Long cardId, Long userId) {
+        Card card = cardMapper.findById(cardId);
+
+        if (card == null || !card.getUserId().equals(userId)) {
+            throw new ForbiddenException("본인 카드만 삭제할 수 있습니다");
+        }
+
+        if (!Boolean.TRUE.equals(card.getIsActive())) {
+            return;
+        }
+
+        cardMapper.updateIsActive(cardId, false);
+    }
+
 }

--- a/src/main/java/org/scoula/common/exception/ForbiddenException.java
+++ b/src/main/java/org/scoula/common/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package org.scoula.common.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class ForbiddenException extends BaseException {
+    public ForbiddenException(String message) {
+        super(message, 403); // 👈 여기 status 403 같이 넘겨야 함
+    }
+}

--- a/src/main/resources/org/scoula/account/mapper/AccountMapper.xml
+++ b/src/main/resources/org/scoula/account/mapper/AccountMapper.xml
@@ -49,5 +49,10 @@
         WHERE user_id = #{userId}
     </select>
 
+    <update id="updateIsActive">
+        UPDATE account
+        SET is_active = #{isActive}
+        WHERE id = #{id}
+    </update>
 
 </mapper>

--- a/src/main/resources/org/scoula/card/mapper/CardMapper.xml
+++ b/src/main/resources/org/scoula/card/mapper/CardMapper.xml
@@ -26,5 +26,10 @@
         WHERE user_id = #{userId}
     </select>
 
+    <update id="updateIsActive">
+        UPDATE card
+        SET is_active = #{isActive}
+        WHERE id = #{id}
+    </update>
 
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
사용자가 연동된 계좌 또는 카드를 해제(삭제)할 수 있도록
account, card 리소스에 대한 삭제 API를 구현합니다.
삭제는 완전 삭제가 아닌 soft-delete 방식으로 처리합니다.

## 📖 작업 내용 
- [x]  account, card 테이블에 is_active 컬럼 존재 여부 확인 및 반영
> 컬럼 없으면 BOOLEAN DEFAULT TRUE로 추가
> 기본값은 true, 삭제 시 false 처리
> 기존 API에서 is_active = true 조건 추가 (예: 잔액 조회, 거래내역 등)

- [x]  DELETE /api/accounts/{accountId}
> 해당 계좌의 is_active 값을 false로 업데이트
> 이미 비활성화된 계좌일 경우 예외 처리 or 무시

- [x]  DELETE /api/cards/{cardId}
> 해당 카드의 is_active 값을 false로 업데이트
> 이미 비활성화된 카드일 경우 예외 처리 or 무시

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
closes #106 
