### PR TITLE
feat: 유저별 계좌/카드 조회 기능 추가

### DIFF
--- a/src/main/java/org/scoula/account/controller/AccountController.java
+++ b/src/main/java/org/scoula/account/controller/AccountController.java
@@ -1,12 +1,15 @@
 package org.scoula.account.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.scoula.account.dto.AccountDto;
 import org.scoula.account.dto.AccountRegisterResponseDto;
 import org.scoula.account.service.AccountService;
 import org.scoula.common.dto.CommonResponseDTO;
 import org.scoula.nhapi.dto.FinAccountRequestDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/accounts")
@@ -49,5 +52,10 @@ public class AccountController {
         return ResponseEntity.ok(CommonResponseDTO.success("계좌 비활성화 완료"));
     }
 
+    @GetMapping("/users/{userId}/accounts")
+    public ResponseEntity<CommonResponseDTO<List<AccountDto>>> getActiveAccounts(@PathVariable Long userId) {
+        List<AccountDto> accounts = accountService.getActiveAccounts(userId);
+        return ResponseEntity.ok(CommonResponseDTO.success("계좌 목록 조회 성공", accounts));
+    }
 
 }

--- a/src/main/java/org/scoula/account/dto/AccountDto.java
+++ b/src/main/java/org/scoula/account/dto/AccountDto.java
@@ -1,0 +1,32 @@
+package org.scoula.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.scoula.account.domain.Account;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountDto {
+
+    private Long id;
+    private String accountNumber;
+    private String productName;
+    private String accountType;
+    private BigDecimal balance;
+
+    public static AccountDto from(Account account) {
+        return AccountDto.builder()
+                .id(account.getId())
+                .accountNumber(account.getAccountNumber())
+                .productName(account.getProductName())
+                .accountType(account.getAccountType())
+                .balance(account.getBalance())
+                .build();
+    }
+}

--- a/src/main/java/org/scoula/account/mapper/AccountMapper.java
+++ b/src/main/java/org/scoula/account/mapper/AccountMapper.java
@@ -20,5 +20,5 @@ public interface AccountMapper {
     Account findById(Long accountId);// 핀어카운트로 계좌 조회
     List<Account> findByUserId(Long userId);
     void updateIsActive(@Param("id") Long id, @Param("isActive") boolean isActive);
-
+    List<Account> findActiveByUserId(Long userId);
 }

--- a/src/main/java/org/scoula/account/service/AccountService.java
+++ b/src/main/java/org/scoula/account/service/AccountService.java
@@ -1,11 +1,16 @@
 package org.scoula.account.service;
 
+import org.scoula.account.dto.AccountDto;
 import org.scoula.nhapi.dto.FinAccountRequestDto;
 import org.scoula.account.dto.AccountRegisterResponseDto;
+
+import java.util.List;
 
 public interface AccountService {
     AccountRegisterResponseDto registerFinAccount(FinAccountRequestDto dto);
     void syncAccountById(Long accountId);
     void syncAllAccountsByUserId(Long userId);
     void deactivateAccount(Long accountId, Long userId);
+    List<AccountDto> getActiveAccounts(Long userId);
+
 }

--- a/src/main/java/org/scoula/account/service/AccountServiceImpl.java
+++ b/src/main/java/org/scoula/account/service/AccountServiceImpl.java
@@ -3,6 +3,7 @@ package org.scoula.account.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.scoula.account.domain.Account;
+import org.scoula.account.dto.AccountDto;
 import org.scoula.account.dto.AccountRegisterResponseDto;
 import org.scoula.account.mapper.AccountMapper;
 import org.scoula.common.exception.BaseException;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -96,4 +98,13 @@ public class AccountServiceImpl implements AccountService {
 
         accountMapper.updateIsActive(accountId, false);
     }
+
+    @Override
+    public List<AccountDto> getActiveAccounts(Long userId) {
+        List<Account> accounts = accountMapper.findActiveByUserId(userId);
+        return accounts.stream()
+                .map(AccountDto::from)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/org/scoula/card/controller/CardController.java
+++ b/src/main/java/org/scoula/card/controller/CardController.java
@@ -1,12 +1,16 @@
 package org.scoula.card.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.scoula.account.dto.AccountDto;
+import org.scoula.card.dto.CardDto;
 import org.scoula.card.dto.CardRegisterResponseDto;
 import org.scoula.card.service.CardService;
 import org.scoula.common.dto.CommonResponseDTO;
 import org.scoula.nhapi.dto.FinCardRequestDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/cards")
@@ -42,4 +46,9 @@ public class CardController {
         return ResponseEntity.ok(CommonResponseDTO.success("카드 비활성화 완료"));
     }
 
+    @GetMapping("/users/{userId}/cards")
+    public ResponseEntity<CommonResponseDTO<List<CardDto>>> getActiveCards(@PathVariable Long userId) {
+        List<CardDto> cards = cardService.getActiveCards(userId);
+        return ResponseEntity.ok(CommonResponseDTO.success("카드 목록 조회 성공", cards));
+    }
 }

--- a/src/main/java/org/scoula/card/dto/CardDto.java
+++ b/src/main/java/org/scoula/card/dto/CardDto.java
@@ -1,0 +1,30 @@
+package org.scoula.card.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.scoula.card.domain.Card;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardDto {
+
+    private Long id;
+    private String cardName;
+    private String cardMaskednum;
+    private String bankName;
+    private String cardType;
+
+    public static CardDto from(Card card) {
+        return CardDto.builder()
+                .id(card.getId())
+                .cardName(card.getCardName())
+                .cardMaskednum(card.getCardMaskednum())
+                .bankName(card.getBankName())
+                .cardType(card.getCardType())
+                .build();
+    }
+}

--- a/src/main/java/org/scoula/card/mapper/CardMapper.java
+++ b/src/main/java/org/scoula/card/mapper/CardMapper.java
@@ -3,6 +3,7 @@ package org.scoula.card.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.scoula.card.domain.Card;
+import org.scoula.card.dto.CardDto;
 
 import java.util.List;
 
@@ -12,4 +13,5 @@ public interface CardMapper {
     Card findById(Long cardId);
     List<Card> findByUserId(Long userId);
     void updateIsActive(@Param("id") Long id, @Param("isActive") boolean isActive);
+    List<Card> findActiveByUserId(Long userId);
 }

--- a/src/main/java/org/scoula/card/service/CardService.java
+++ b/src/main/java/org/scoula/card/service/CardService.java
@@ -1,11 +1,15 @@
 package org.scoula.card.service;
 
+import org.scoula.card.dto.CardDto;
 import org.scoula.card.dto.CardRegisterResponseDto;
 import org.scoula.nhapi.dto.FinCardRequestDto;
+
+import java.util.List;
 
 public interface CardService {
     CardRegisterResponseDto registerCard(FinCardRequestDto dto);
     void syncCardById(Long cardId);
     void syncAllCardsByUserId(Long userId);
     void deactivateCard(Long cardId, Long userId);
+    List<CardDto> getActiveCards(Long userId);
 }

--- a/src/main/java/org/scoula/card/service/CardServiceImpl.java
+++ b/src/main/java/org/scoula/card/service/CardServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.scoula.card.domain.Card;
+import org.scoula.card.dto.CardDto;
 import org.scoula.card.dto.CardRegisterResponseDto;
 import org.scoula.common.exception.BaseException;
 import org.scoula.common.exception.ForbiddenException;
@@ -14,6 +15,7 @@ import org.scoula.transactions.service.CardTransactionService;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -112,5 +114,15 @@ public class CardServiceImpl implements CardService {
 
         cardMapper.updateIsActive(cardId, false);
     }
+
+    @Override
+    public List<CardDto> getActiveCards(Long userId) {
+        List<Card> cards = cardMapper.findActiveByUserId(userId);
+        return cards.stream()
+                .map(CardDto::from)
+                .collect(Collectors.toList());
+    }
+
+
 
 }

--- a/src/main/resources/org/scoula/account/mapper/AccountMapper.xml
+++ b/src/main/resources/org/scoula/account/mapper/AccountMapper.xml
@@ -55,4 +55,11 @@
         WHERE id = #{id}
     </update>
 
+    <select id="findActiveByUserId" resultType="org.scoula.account.domain.Account">
+        SELECT * FROM account
+        WHERE user_id = #{userId}
+          AND is_active = TRUE
+    </select>
+
+
 </mapper>

--- a/src/main/resources/org/scoula/card/mapper/CardMapper.xml
+++ b/src/main/resources/org/scoula/card/mapper/CardMapper.xml
@@ -32,4 +32,11 @@
         WHERE id = #{id}
     </update>
 
+    <select id="findActiveByUserId" resultType="org.scoula.card.domain.Card">
+        SELECT * FROM card
+        WHERE user_id = #{userId}
+          AND is_active = TRUE
+    </select>
+
+
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
유저 ID 기반으로 연동된 계좌 및 카드 목록을 조회할 수 있도록 API를 구현했습니다.  
각 API는 비활성 자산(`is_active = false`)을 제외하고,  
`user_id` 일치 조건을 통해 본인 자산만 응답되도록 처리합니다.

## 📖 작업 내용 
### ✅ 계좌 목록 조회 API
- `GET /api/users/{userId}/accounts` 엔드포인트 추가
- `account` 테이블에서 `is_active = true` 필터 적용
- 사용자 본인의 계좌만 조회 (`userId` 매핑)

### ✅ 카드 목록 조회 API
- `GET /api/users/{userId}/cards` 엔드포인트 추가
- `card` 테이블에서 `is_active = true` 필터 적용
- 사용자 본인의 카드만 조회 (`userId` 매핑)

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
closes #111 