### PR TITLE
Refactor/#113 is active filter

### DIFF
--- a/src/main/java/org/scoula/account/mapper/AccountMapper.java
+++ b/src/main/java/org/scoula/account/mapper/AccountMapper.java
@@ -18,7 +18,7 @@ public interface AccountMapper {
             @Param("balance") BigDecimal balance
     );
     Account findById(Long accountId);// 핀어카운트로 계좌 조회
-    List<Account> findByUserId(Long userId);
     void updateIsActive(@Param("id") Long id, @Param("isActive") boolean isActive);
     List<Account> findActiveByUserId(Long userId);
+    List<Account> findByIdList(List<Long> ids);
 }

--- a/src/main/java/org/scoula/account/service/AccountServiceImpl.java
+++ b/src/main/java/org/scoula/account/service/AccountServiceImpl.java
@@ -63,7 +63,9 @@ public class AccountServiceImpl implements AccountService {
     public void syncAccountById(Long accountId) {
         Account account = accountMapper.findById(accountId);
         if (account == null) throw new BaseException("해당 계좌가 존재하지 않습니다.", 404);
-
+        if (!Boolean.TRUE.equals(account.getIsActive())) {
+            throw new BaseException("비활성화된 계좌입니다.", 400);
+        }
         // 거래내역 동기화 (isInitial = false)
         accountTransactionService.syncAccountTransactions(account, false);
 
@@ -76,7 +78,7 @@ public class AccountServiceImpl implements AccountService {
 
     @Override
     public void syncAllAccountsByUserId(Long userId) {
-        List<Account> accounts = accountMapper.findByUserId(userId);
+        List<Account> accounts = accountMapper.findActiveByUserId(userId);
         for (Account acc : accounts) {
             accountTransactionService.syncAccountTransactions(acc, false);
             BigDecimal newBalance = nhAccountService.callInquireBalance(acc.getPinAccountNumber());

--- a/src/main/java/org/scoula/card/mapper/CardMapper.java
+++ b/src/main/java/org/scoula/card/mapper/CardMapper.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface CardMapper {
     void insertCard(Card card);
     Card findById(Long cardId);
-    List<Card> findByUserId(Long userId);
     void updateIsActive(@Param("id") Long id, @Param("isActive") boolean isActive);
     List<Card> findActiveByUserId(Long userId);
+    List<Card> findByIdList(List<Long> ids);
 }

--- a/src/main/java/org/scoula/card/service/CardServiceImpl.java
+++ b/src/main/java/org/scoula/card/service/CardServiceImpl.java
@@ -70,7 +70,13 @@ public class CardServiceImpl implements CardService {
     @Override
     public void syncCardById(Long cardId) {
         Card card = cardMapper.findById(cardId);
-        if (card == null) throw new BaseException("해당 카드가 존재하지 않습니다.", 404);
+        if (card == null) {
+            throw new BaseException("해당 카드가 존재하지 않습니다.", 404);
+        }
+
+        if (!Boolean.TRUE.equals(card.getIsActive())) {
+            throw new BaseException("비활성화된 카드입니다.", 400);
+        }
 
         cardTransactionService.syncCardTransactions(
                 card.getUserId(),
@@ -84,7 +90,7 @@ public class CardServiceImpl implements CardService {
 
     @Override
     public void syncAllCardsByUserId(Long userId) {
-        List<Card> cards = cardMapper.findByUserId(userId);
+        List<Card> cards = cardMapper.findActiveByUserId(userId);
         if (cards == null || cards.isEmpty()) {
             log.info("❗️ 동기화할 카드가 없습니다. userId={}", userId);
             return;

--- a/src/main/java/org/scoula/monthreport/domain/LedgerTransaction.java
+++ b/src/main/java/org/scoula/monthreport/domain/LedgerTransaction.java
@@ -8,4 +8,7 @@ import java.math.BigDecimal;
 public class LedgerTransaction {
     private BigDecimal amount;
     private String categoryName;
+    private String sourceType;
+    private Long accountId;
+    private Long cardId;
 }

--- a/src/main/java/org/scoula/monthreport/service/MonthReportGeneratorImpl.java
+++ b/src/main/java/org/scoula/monthreport/service/MonthReportGeneratorImpl.java
@@ -3,7 +3,9 @@ package org.scoula.monthreport.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.scoula.account.domain.Account;
 import org.scoula.account.mapper.AccountMapper;
+import org.scoula.card.domain.Card;
 import org.scoula.card.mapper.CardMapper;
 import org.scoula.monthreport.domain.LedgerTransaction;
 import org.scoula.monthreport.domain.MonthReport;
@@ -35,14 +37,33 @@ public class MonthReportGeneratorImpl implements MonthReportGenerator {
         List<LedgerTransaction> txList = monthReportMapper.findLedgerTransactions(userId, from, to);
         if (txList.isEmpty()) return;
 
+        // 해당 month가지 결제된 계좌/카드 ID 수집
+        Set<Long> accountIds = txList.stream()
+                .filter(tx -> "ACCOUNT".equals(tx.getSourceType()) && tx.getAccountId() != null)
+                .map(LedgerTransaction::getAccountId)
+                .collect(Collectors.toSet());
+
+        Set<Long> cardIds = txList.stream()
+                .filter(tx -> "CARD".equals(tx.getSourceType()) && tx.getCardId() != null)
+                .map(LedgerTransaction::getCardId)
+                .collect(Collectors.toSet());
+
+        Map<Long, Account> accountMap = accountIds.isEmpty() ? Collections.emptyMap() :
+                accountMapper.findByIdList(new ArrayList<>(accountIds)).stream()
+                        .collect(Collectors.toMap(Account::getId, a -> a));
+
+        Map<Long, Card> cardMap = cardIds.isEmpty() ? Collections.emptyMap() :
+                cardMapper.findByIdList(new ArrayList<>(cardIds)).stream()
+                        .collect(Collectors.toMap(Card::getId, c -> c));
+
         List<LedgerTransaction> filteredTxList = txList.stream()
                 .filter(tx -> {
                     if ("ACCOUNT".equals(tx.getSourceType()) && tx.getAccountId() != null) {
-                        var acc = accountMapper.findById(tx.getAccountId());
+                        Account acc = accountMap.get(tx.getAccountId());
                         return acc != null && Boolean.TRUE.equals(acc.getIsActive());
                     }
                     if ("CARD".equals(tx.getSourceType()) && tx.getCardId() != null) {
-                        var card = cardMapper.findById(tx.getCardId());
+                        Card card = cardMap.get(tx.getCardId());
                         return card != null && Boolean.TRUE.equals(card.getIsActive());
                     }
                     return false;
@@ -68,7 +89,7 @@ public class MonthReportGeneratorImpl implements MonthReportGenerator {
         MonthReport prev = monthReportMapper.findMonthReport(userId, prevMonth.toString());
 
         BigDecimal compareExpense = (prev != null) ? totalExpense.subtract(prev.getTotalExpense()) : BigDecimal.ZERO;
-        BigDecimal totalSaving = new BigDecimal("300000"); // FIXME: 나중에 동적으로 바꾸는 게 좋음
+        BigDecimal totalSaving = new BigDecimal("300000"); // FIXME: 동적으로 설정할 것
         BigDecimal compareSaving = (prev != null) ? totalSaving.subtract(prev.getTotalSaving()) : BigDecimal.ZERO;
 
         BigDecimal denominator = totalExpense.add(totalSaving);

--- a/src/main/java/org/scoula/transactions/service/AccountTransactionServiceImpl.java
+++ b/src/main/java/org/scoula/transactions/service/AccountTransactionServiceImpl.java
@@ -3,6 +3,8 @@ package org.scoula.transactions.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.scoula.account.domain.Account;
+import org.scoula.account.mapper.AccountMapper;
+import org.scoula.common.exception.BaseException;
 import org.scoula.nhapi.dto.NhAccountTransactionResponseDto;
 import org.scoula.nhapi.service.NhAccountService;
 import org.scoula.transactions.domain.AccountTransaction;
@@ -26,11 +28,17 @@ public class AccountTransactionServiceImpl implements AccountTransactionService 
     private final NhAccountService nhAccountService;
     private final AccountTransactionMapper accountTransactionMapper;
     private final LedgerMapper ledgerMapper;
+    private final AccountMapper accountMapper;
 
     @Override
     public List<AccountTransactionDto> getTransactions(Long userId, Long accountId, String from, String to) {
-        List<AccountTransaction> txList = accountTransactionMapper.findAccountTransactions(userId, accountId, from, to);
+        Account acc = accountMapper.findById(accountId);
+        if (acc == null) throw new BaseException("해당 계좌가 존재하지 않습니다.", 404);
+        if (!Boolean.TRUE.equals(acc.getIsActive())) {
+            throw new BaseException("비활성화된 계좌입니다.", 400);
+        }
 
+        List<AccountTransaction> txList = accountTransactionMapper.findAccountTransactions(userId, accountId, from, to);
         if (txList == null || txList.isEmpty()) {
             throw new AccountTransactionNotFoundException();
         }

--- a/src/main/java/org/scoula/transactions/service/LedgerServiceImpl.java
+++ b/src/main/java/org/scoula/transactions/service/LedgerServiceImpl.java
@@ -1,6 +1,11 @@
 package org.scoula.transactions.service;
 
 import lombok.RequiredArgsConstructor;
+import org.scoula.account.domain.Account;
+import org.scoula.account.mapper.AccountMapper;
+import org.scoula.card.domain.Card;
+import org.scoula.card.mapper.CardMapper;
+import org.scoula.common.exception.BaseException;
 import org.scoula.transactions.domain.Ledger;
 import org.scoula.transactions.dto.LedgerDetailDto;
 import org.scoula.transactions.dto.LedgerDto;
@@ -18,6 +23,8 @@ import java.util.List;
 public class LedgerServiceImpl implements LedgerService {
 
     private final LedgerMapper ledgerMapper;
+    private final AccountMapper accountMapper;
+    private final CardMapper cardMapper;
 
     @Override
     public List<LedgerDto> getLedgers(Long userId, String from, String to, String category) {
@@ -36,9 +43,21 @@ public class LedgerServiceImpl implements LedgerService {
     public LedgerDetailDto getLedgerDetail(Long userId, Long ledgerId) {
         Ledger ledger = ledgerMapper.findLedgerDetail(userId, ledgerId);
 
-        if (ledger == null) {
-            throw new LedgerNotFoundException();
+        if (ledger == null) throw new LedgerNotFoundException();
+
+        if (ledger.getAccountId() != null) {
+            Account acc = accountMapper.findById(ledger.getAccountId());
+            if (!Boolean.TRUE.equals(acc.getIsActive())) {
+                throw new BaseException("비활성화된 계좌입니다.", 400);
+            }
         }
+        if (ledger.getCardId() != null) {
+            Card card = cardMapper.findById(ledger.getCardId());
+            if (!Boolean.TRUE.equals(card.getIsActive())) {
+                throw new BaseException("비활성화된 카드입니다.", 400);
+            }
+        }
+
 
         return convertToDetailDto(ledger);
     }

--- a/src/main/resources/org/scoula/account/mapper/AccountMapper.xml
+++ b/src/main/resources/org/scoula/account/mapper/AccountMapper.xml
@@ -15,7 +15,8 @@
             account_number,
             product_name,
             account_type,
-            balance
+            balance,
+            is_active
         ) VALUES (
                      #{userId},
                      #{pinAccountNumber},
@@ -23,7 +24,7 @@
                      #{accountNumber},
                      #{productName},
                      #{accountType},
-                     #{balance}
+                     #{balance}, TRUE
                  )
     </insert>
 
@@ -34,7 +35,6 @@
         WHERE user_id = #{userId}
           AND pin_account_number = #{pinAccountNumber}
     </update>
-
 
     <select id="findById" resultType="org.scoula.account.domain.Account">
         SELECT *
@@ -47,6 +47,7 @@
                product_name, account_type, balance, created_at
         FROM account
         WHERE user_id = #{userId}
+          AND is_active = TRUE
     </select>
 
     <update id="updateIsActive">
@@ -55,10 +56,13 @@
         WHERE id = #{id}
     </update>
 
-    <select id="findActiveByUserId" resultType="org.scoula.account.domain.Account">
+    <select id="findByIdList" resultType="org.scoula.account.domain.Account">
         SELECT * FROM account
-        WHERE user_id = #{userId}
-          AND is_active = TRUE
+        WHERE is_active = TRUE
+        AND id IN
+        <foreach collection="list" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
     </select>
 
 

--- a/src/main/resources/org/scoula/card/mapper/CardMapper.xml
+++ b/src/main/resources/org/scoula/card/mapper/CardMapper.xml
@@ -7,10 +7,10 @@
     <insert id="insertCard" parameterType="org.scoula.card.domain.Card">
         INSERT INTO card (
             user_id, fin_card_number, back_code, bank_name, card_name,
-            card_maskednum, card_member_type, card_type
+            card_maskednum, card_member_type, card_type, is_active
         ) VALUES (
                      #{userId}, #{finCardNumber}, #{backCode}, #{bankName}, #{cardName},
-                     #{cardMaskednum}, #{cardMemberType}, #{cardType}
+                     #{cardMaskednum}, #{cardMemberType}, #{cardType}, TRUE
                  )
     </insert>
 
@@ -18,12 +18,6 @@
         SELECT *
         FROM card
         WHERE id = #{cardId}
-    </select>
-
-    <select id="findByUserId" resultType="org.scoula.card.domain.Card">
-        SELECT *
-        FROM card
-        WHERE user_id = #{userId}
     </select>
 
     <update id="updateIsActive">
@@ -38,5 +32,13 @@
           AND is_active = TRUE
     </select>
 
+    <select id="findByIdList" resultType="org.scoula.card.domain.Card">
+        SELECT * FROM card
+        WHERE is_active = TRUE
+        AND id IN
+        <foreach collection="list" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </select>
 
 </mapper>

--- a/src/main/resources/org/scoula/monthreport/mapper/MonthReportMapper.xml
+++ b/src/main/resources/org/scoula/monthreport/mapper/MonthReportMapper.xml
@@ -24,14 +24,19 @@
 
     <!-- 💳 해당 월 ledger 조회 -->
     <select id="findLedgerTransactions" resultType="org.scoula.monthreport.domain.LedgerTransaction">
-        SELECT amount, c.label AS categoryName
+        SELECT
+            l.amount,
+            c.label AS categoryName,
+            l.source_type AS sourceType,
+            l.account_id AS accountId,
+            l.card_id AS cardId
         FROM ledger l
                  JOIN tr_category c ON l.category_id = c.id
         WHERE l.user_id = #{userId}
-          AND l.source_type = 'CARD'
-          AND l.type = 'EXPENSE'
           AND l.date BETWEEN #{from} AND #{to}
+          AND l.type = 'EXPENSE'
     </select>
+
 
     <!-- 🔁 전월 리포트 조회 -->
     <select id="findMonthReport" resultType="org.scoula.monthreport.domain.MonthReport">

--- a/src/main/resources/org/scoula/transactions/mapper/LedgerMapper.xml
+++ b/src/main/resources/org/scoula/transactions/mapper/LedgerMapper.xml
@@ -10,11 +10,15 @@
         SELECT
         l.id, l.user_id, l.source_type, l.source_name,
         l.amount, l.type,
-        c.label AS category,  <!-- label = 사용자 노출용 -->
+        c.label AS category,
         l.date, l.merchant_name
         FROM ledger l
         JOIN tr_category c ON l.category_id = c.id
+        LEFT JOIN account a ON l.account_id = a.id
+        LEFT JOIN card cd ON l.card_id = cd.id
         WHERE l.user_id = #{userId}
+        AND (l.account_id IS NULL OR a.is_active = TRUE)
+        AND (l.card_id IS NULL OR cd.is_active = TRUE)
         <if test="from != null">AND l.date &gt;= #{from}</if>
         <if test="to != null">AND l.date &lt;= #{to}</if>
         <if test="category != null">AND c.name = #{category}</if>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

비활성 자산(계좌/카드) soft-delete 처리(`is_active = false`)에 따른 전체 기능 리팩토링 및 성능 최적화 (Map 캐싱 적용 포함)

## 📖 작업 내용 

- `Account.java`, `Card.java`에 `Boolean isActive` 필드 추가
- soft-delete 방식 삭제 구현 (`is_active = false`)
- `accountMapper.xml`, `cardMapper.xml` → 목록/조회 쿼리에 `is_active = TRUE` 필터 추가
- 계좌/카드 API 전체에 비활성 자산 무시 처리 적용
  - `/api/accounts/{id}/sync` → 비활성 계좌 예외
  - `/api/cards/{id}/sync` → 비활성 카드 예외
- 거래내역 API 필터링 적용
  - `LedgerService`, `AccountTransactionService`, `CardTransactionService` 에서 `is_active` 검증 추가
- 리포트 생성 로직 개선
  - `MonthReportGeneratorImpl`에서 비활성 자산 거래 제거
  - 계좌/카드 ID 수집 후 `findByIdList`로 한방 조회 → `Map<Long, T>` 캐싱
  - 거래 수 기준 N번 DB조회 → 1~2회 조회로 최적화

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#113`)

## ✋ 질문 사항



## 🔗 관련 이슈

 closes #113
