### PR TITLE
feat: 챌린지 결과 보상 로직 및 응답 개선

### DIFF
--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -40,12 +40,13 @@ public class ChallengeController {
     public CommonResponseDTO<List<ChallengeListResponseDTO>> getChallenges(
             @RequestParam(value = "type", required = false) ChallengeType type,
             @RequestParam(value = "status", required = false) ChallengeStatus status,
+            @RequestParam(value = "participating", required = false) Boolean participating,
             HttpServletRequest request) {
 
         String bearer = request.getHeader("Authorization");
         Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
 
-        List<ChallengeListResponseDTO> challenges = challengeService.getChallenges(userId, type, status);
+        List<ChallengeListResponseDTO> challenges = challengeService.getChallenges(userId, type, status, participating);
         return CommonResponseDTO.success("챌린지 리스트 조회 성공", challenges);
     }
 
@@ -106,6 +107,5 @@ public class ChallengeController {
         boolean result = challengeService.hasUnconfirmedResult(userId);
         return CommonResponseDTO.success("미확인 결과 존재 여부 확인", result);
     }
-
 
 }

--- a/src/main/java/org/scoula/challenge/domain/Challenge.java
+++ b/src/main/java/org/scoula/challenge/domain/Challenge.java
@@ -23,5 +23,5 @@ public class Challenge {
     private String goalType; // enum: 소비, 횟수 등
     private Integer goalValue;
     private Integer participantCount;
-
+    private Integer rewardPoint;
 }

--- a/src/main/java/org/scoula/challenge/dto/ChallengeDetailResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeDetailResponseDTO.java
@@ -24,6 +24,8 @@ public class ChallengeDetailResponseDTO {
     private Boolean isMine;
     private Double myProgress;
     private Integer participantsCount;
+    private Boolean isResultCheck;
+    private String categoryName; // 추가
 
     // GROUP 전용
     private List<ChallengeMemberDTO> members;

--- a/src/main/java/org/scoula/challenge/dto/ChallengeListResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeListResponseDTO.java
@@ -13,6 +13,7 @@ public class ChallengeListResponseDTO {
     private Long id;
     private String title;
     private ChallengeType type;
+    private String categoryName; // 추가
 
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
@@ -23,4 +24,6 @@ public class ChallengeListResponseDTO {
     private boolean isParticipating; // 나의 참여 여부
     private Double myProgressRate;   // 개인/소그룹 챌린지일 경우
     private int participantsCount;   // 모집중인 경우
+
+    private Boolean isResultCheck;
 }

--- a/src/main/java/org/scoula/challenge/exception/ChallengeGoalTooBigException.java
+++ b/src/main/java/org/scoula/challenge/exception/ChallengeGoalTooBigException.java
@@ -1,0 +1,9 @@
+package org.scoula.challenge.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class ChallengeGoalTooBigException extends BaseException {
+    public ChallengeGoalTooBigException() {
+        super("챌린지 목표 금액은 10,000,000원 이하이어야 합니다.", 400);
+    }
+}

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -75,7 +75,15 @@ public interface ChallengeMapper {
     int getActualRewardPoint(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
     void markResultChecked(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
     boolean existsUnconfirmedCompletedChallenge(@Param("userId") Long userId);
+    Boolean isResultChecked(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
 
+    // 챌린지 결과 계산
+
+    int countSuccessMembers(@Param("challengeId") Long challengeId);
+
+    void saveActualRewardPoint(@Param("userId") Long userId,
+                               @Param("challengeId") Long challengeId,
+                               @Param("actualRewardPoint") int actualRewardPoint);
 
 }
 

--- a/src/main/java/org/scoula/challenge/service/ChallengeService.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface ChallengeService {
     ChallengeCreateResponseDTO createChallenge(Long userId, ChallengeCreateRequestDTO req);
-    List<ChallengeListResponseDTO> getChallenges(Long userId, ChallengeType type, ChallengeStatus status);
+    List<ChallengeListResponseDTO> getChallenges(Long userId, ChallengeType type, ChallengeStatus status, Boolean participating);
     ChallengeDetailResponseDTO getChallengeDetail(Long userId, Long challengeId);
     void joinChallenge(Long userId, Long challengeId, Integer password);
     ChallengeSummaryResponseDTO getChallengeSummary(Long userId);

--- a/src/main/java/org/scoula/coin/exception/InsufficientCoinException.java
+++ b/src/main/java/org/scoula/coin/exception/InsufficientCoinException.java
@@ -1,0 +1,9 @@
+package org.scoula.coin.exception;
+
+import org.scoula.common.exception.BaseException;
+
+public class InsufficientCoinException extends BaseException {
+    public InsufficientCoinException() {
+        super("보유한 포인트가 부족합니다. (최소 100P 필요)", 400);
+    }
+}

--- a/src/main/java/org/scoula/coin/mapper/CoinMapper.java
+++ b/src/main/java/org/scoula/coin/mapper/CoinMapper.java
@@ -1,0 +1,20 @@
+package org.scoula.coin.mapper;
+
+import org.apache.ibatis.annotations.Param;
+
+public interface CoinMapper {
+    void subtractCoin(@Param("userId") Long userId, @Param("amount") int amount);
+    void addCoinAmount(@Param("userId") Long userId, @Param("amount") int amount);
+    void insertCoinHistory(@Param("userId") Long userId,
+                           @Param("amount") int amount,
+                           @Param("type") String type,
+                           @Param("coinType") String coinType);
+
+    int getUserCoin(@Param("userId") Long userId);
+
+    // 회원가입시 초기 데이터 생성
+    void insertInitialCoin(@Param("userId") Long userId);
+
+
+}
+

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -37,7 +37,8 @@ import javax.sql.DataSource;
         "org.scoula.avatar.mapper",
         "org.scoula.card.mapper",
         "org.scoula.alarm.mapper",
-        "org.scoula.monthreport.mapper"
+        "org.scoula.monthreport.mapper",
+        "org.scoula.coin.mapper"
 })
 @ComponentScan(basePackages = {
         "org.scoula.security",

--- a/src/main/java/org/scoula/user/service/UserServiceImpl.java
+++ b/src/main/java/org/scoula/user/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package org.scoula.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.scoula.coin.mapper.CoinMapper;
 import org.scoula.common.redis.RedisService;
 import org.scoula.user.domain.User;
 import org.scoula.user.domain.UserStatus;
@@ -31,6 +32,7 @@ import java.util.UUID;
 public class UserServiceImpl implements UserService {
     private final UserMapper userMapper;
     private final UserStatusMapper userStatusMapper;
+    private final CoinMapper coinMapper;
     private final JwtUtil jwtUtil;
     private final RedisService redisService;
     private final PasswordEncoder encoder;
@@ -85,7 +87,12 @@ public class UserServiceImpl implements UserService {
         status.setNickname(nickname);
         status.setLevel(UserLevel.SEEDLING.getLabel()); // → "금융새싹"
         userStatusMapper.save(status); // 2. 상태 저장
-        userMapper.insertUserChallengeSummary(user.getId()); // 3. 챌린지 요약 0으로 초기화
+
+        // 3. coin row 초기화
+        coinMapper.insertInitialCoin(user.getId());
+
+        // 4. 챌린지 요약 초기화
+        userMapper.insertUserChallengeSummary(user.getId());
 
         return UserResponseDTO.builder()
                 .id(user.getId())

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -184,5 +184,23 @@
         )
     </select>
 
+    <select id="isResultChecked" resultType="boolean">
+        SELECT result_checked FROM user_challenge
+        WHERE user_id = #{userId} AND challenge_id = #{challengeId}
+    </select>
+
+    <!-- 성공한 유저 수 조회 -->
+    <select id="countSuccessMembers" resultType="int">
+        SELECT COUNT(*) FROM user_challenge
+        WHERE challenge_id = #{challengeId} AND is_success = 1
+    </select>
+
+    <!-- actual_reward_point 저장 -->
+    <update id="saveActualRewardPoint">
+        UPDATE user_challenge
+        SET actual_reward_point = #{actualRewardPoint}
+        WHERE user_id = #{userId} AND challenge_id = #{challengeId}
+    </update>
+
 
 </mapper>

--- a/src/main/resources/org/scoula/coin/mapper/CoinMapper.xml
+++ b/src/main/resources/org/scoula/coin/mapper/CoinMapper.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.scoula.coin.mapper.CoinMapper">
+
+    <update id="subtractCoin">
+        UPDATE coin
+        SET amount = amount - #{amount},
+            cumulative_amount = cumulative_amount - #{amount},
+            monthly_cumulative_amount = monthly_cumulative_amount - #{amount}
+        WHERE id = #{userId}
+    </update>
+
+    <update id="addCoinAmount">
+        UPDATE coin
+        SET amount = amount + #{amount},
+            cumulative_amount = cumulative_amount + #{amount},
+            monthly_cumulative_amount = monthly_cumulative_amount + #{amount}
+        WHERE id = #{userId}
+    </update>
+
+    <insert id="insertCoinHistory">
+        INSERT INTO coin_history (user_id, amount, type, coin_type)
+        VALUES (#{userId}, #{amount}, #{type}, #{coinType})
+    </insert>
+
+    <select id="getUserCoin" resultType="int">
+        SELECT amount FROM coin WHERE id = #{userId}
+    </select>
+
+    <insert id="insertInitialCoin">
+        INSERT INTO coin (id, amount, cumulative_amount, monthly_cumulative_amount)
+        VALUES (#{userId}, 0, 0, 0)
+    </insert>
+
+
+</mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
챌린지 결과 확인 시 포인트 보상 지급 오류 수정 및 카테고리 이름 포함 등 API 응답 개선

## 📖 작업 내용 
### 챌린지 포인트 관련
> 유저 회원가입시 coin 테이블 에 유저 코인 데이터 초기 생성
- coin 테이블과 coin_history 간 외래키 오류 해결
- 챌린지 성공 시 최종 포인트 계산 및 지급 (엔빵 포함)

### 챌린지 리스트조회 및 상세조회 수정
- 응답 DTO에 `categoryName` 추가 (리스트/상세조회 모두)
- 리스트 조회 시 `participating` 쿼리 파라미터 추가로 필터링 가능
- isResultCheck 플래그 포함으로 결과 확인 여부 응답
- 개인 챌린지, 소그룹 챌린지 등 다양한 조합 테스트 완료

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [x] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다.

## ✋ 질문 사항
- 없음

## 🔗 관련 이슈
- closes #100 
