### PR TITLE
Feat/#105 logout service

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -27,9 +27,8 @@ ALTER TABLE `user`
 ALTER TABLE `user`
     ADD CONSTRAINT uq_user_email UNIQUE (`email`);
 
-
 ALTER TABLE `user`
-    ADD COLUMN auth_pw VARBINARY(255) NOT NULL ;
+    ADD COLUMN auth_pw VARBINARY(255);
 
 -- 2. 유저 상태 (닉네임, 레벨)
 DROP TABLE IF EXISTS `user_status`;

--- a/database.sql
+++ b/database.sql
@@ -28,6 +28,9 @@ ALTER TABLE `user`
     ADD CONSTRAINT uq_user_email UNIQUE (`email`);
 
 
+ALTER TABLE `user`
+    ADD COLUMN auth_pw VARBINARY(255) NOT NULL ;
+
 -- 2. 유저 상태 (닉네임, 레벨)
 DROP TABLE IF EXISTS `user_status`;
 CREATE TABLE `user_status` (

--- a/src/main/java/org/scoula/common/redis/RedisKeyPrefix.java
+++ b/src/main/java/org/scoula/common/redis/RedisKeyPrefix.java
@@ -10,4 +10,6 @@ public class RedisKeyPrefix {
     public static final String VERIFY_TOKEN = "VT:";
     public static final long VERIFY_TOKEN_TTL = 10L; // 10분
     public static final TimeUnit VERIFY_TOKEN_UNIT = TimeUnit.MINUTES;
+
+    public static final String BLACKLIST_TOKEN = "BT:";
 }

--- a/src/main/java/org/scoula/common/redis/RedisService.java
+++ b/src/main/java/org/scoula/common/redis/RedisService.java
@@ -1,7 +1,10 @@
 package org.scoula.common.redis;
 
+import org.scoula.security.util.JwtUtil;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 
@@ -9,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RedisService {
     private final StringRedisTemplate redis;
+    private final StringRedisTemplate blackList;
+    private final JwtUtil jwtUtil;
 
     public void saveRefreshToken(Long userId, String token) {
         try {
@@ -32,6 +37,28 @@ public class RedisService {
         redis.delete(RedisKeyPrefix.REFRESH_TOKEN + userId);
     }
 
+    public void blacklistAccessToken(String accessToken) {
+
+        // 토큰에서 만료 시간을 추출하여 남은 유효 시간을 계산
+        Date expiration = jwtUtil.getExpirationDateFromToken(accessToken);
+        long remainingTime = expiration.getTime() - System.currentTimeMillis();
+
+        if (remainingTime > 0) {
+            // 토큰 자체를 키로 사용하여 블랙리스트에 저장
+            blackList.opsForValue().set(
+                    RedisKeyPrefix.BLACKLIST_TOKEN + accessToken,
+                    accessToken,
+                    remainingTime,
+                    TimeUnit.MILLISECONDS
+            );
+        }
+    }
+
+    //블랙리스트에 있는 access token인지 검증
+    public boolean isTokenBlacklisted(String token) {
+        String key = RedisKeyPrefix.BLACKLIST_TOKEN + token;
+        return blackList.hasKey(key);
+    }
 
 
     // 이메일 인증시에 사용하려고 했던 것들

--- a/src/main/java/org/scoula/security/Exception/BlackListException.java
+++ b/src/main/java/org/scoula/security/Exception/BlackListException.java
@@ -1,0 +1,9 @@
+package org.scoula.security.Exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class BlackListException extends AuthenticationException {
+    public BlackListException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/scoula/security/filter/AuthenticationErrorFilter.java
+++ b/src/main/java/org/scoula/security/filter/AuthenticationErrorFilter.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
+import org.scoula.security.Exception.BlackListException;
 import org.scoula.security.util.JsonResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -24,7 +25,7 @@ public class AuthenticationErrorFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
             JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, "토큰의 유효시간이 지났습니다.");
-        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException e) {
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | BlackListException e) {
             JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, e.getMessage());
         } catch (ServletException e) {
             JsonResponse.sendError(response, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/src/main/java/org/scoula/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/scoula/security/filter/JwtAuthenticationFilter.java
@@ -47,9 +47,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = bearerToken.substring(BEARER_PREFIX.length());
 
             //블랙리스트에 등록된 access 토큰인 경우 예외처리
-//            if(redisService.isTokenBlacklisted(token)){
-//                throw new BlackListException("블랙리스트에 등록된 토큰입니다.");
-//            }
+            if(redisService.isTokenBlacklisted(token)){
+                throw new BlackListException("블랙리스트에 등록된 토큰입니다.");
+            }
 
             if (jwtUtil.validateToken(token)) {
                 Authentication authentication = getAuthentication(token);

--- a/src/main/java/org/scoula/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/scoula/security/filter/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.scoula.common.redis.RedisService;
+import org.scoula.security.Exception.BlackListException;
 import org.scoula.security.util.JwtUtil;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -45,9 +46,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
             String token = bearerToken.substring(BEARER_PREFIX.length());
 
-            if(redisService.isTokenBlacklisted(token)){
-                throw new ExpiredJwtException(null, null, "블랙리스트에 등록된 토큰입니다.");
-            }
+            //블랙리스트에 등록된 access 토큰인 경우 예외처리
+//            if(redisService.isTokenBlacklisted(token)){
+//                throw new BlackListException("블랙리스트에 등록된 토큰입니다.");
+//            }
 
             if (jwtUtil.validateToken(token)) {
                 Authentication authentication = getAuthentication(token);

--- a/src/main/java/org/scoula/security/util/JwtUtil.java
+++ b/src/main/java/org/scoula/security/util/JwtUtil.java
@@ -72,4 +72,11 @@ public class JwtUtil {
                 .getBody();
     }
 
+    public Date getExpirationDateFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getExpiration();
+    }
 }

--- a/src/main/java/org/scoula/user/controller/AuthController.java
+++ b/src/main/java/org/scoula/user/controller/AuthController.java
@@ -1,5 +1,8 @@
 package org.scoula.user.controller;
 
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.scoula.common.redis.RedisService;
@@ -34,6 +37,7 @@ public class AuthController {
     }
 
     //@AuthenticationPrincipal도 사용가능
+    //swagger에서 테스트할 경우, 꼭 토큰 앞에 Bearer<공백> 문자열을 붙이기
     @PostMapping("/logout")
     public CommonResponseDTO<Void> logout(@RequestHeader("Authorization") String bearerToken) {
 
@@ -45,5 +49,13 @@ public class AuthController {
     @GetMapping("/test-redis")
     public String testToken(@RequestParam Long id) {
         return redisService.getRefreshToken(id);
+    }
+
+
+    @ApiOperation(value = "사용자 로그인", notes = "이메일과 비밀번호로 로그인하고 JWT 토큰을 발급받습니다.")
+    @PostMapping("/login")
+    public void swaggerLoginForDocs(@RequestBody UserLoginRequestDTO request) {
+        // 실제 요청은 JwtEmailPasswordAuthenticationFilter가 가로채서 처리합니다.
+        throw new IllegalStateException("swagger 상 필터호출을 위한 엔드포인트입니다.");
     }
 }

--- a/src/main/java/org/scoula/user/controller/AuthController.java
+++ b/src/main/java/org/scoula/user/controller/AuthController.java
@@ -33,6 +33,15 @@ public class AuthController {
         return CommonResponseDTO.success("토큰 재발급 성공", token);
     }
 
+    //@AuthenticationPrincipal도 사용가능
+    @PostMapping("/logout")
+    public CommonResponseDTO<Void> logout(@RequestHeader("Authorization") String bearerToken) {
+
+        userService.logout(bearerToken);
+        // 클라이언트에 성공 응답 전송
+        return CommonResponseDTO.success("로그아웃 성공");
+    }
+
     @GetMapping("/test-redis")
     public String testToken(@RequestParam Long id) {
         return redisService.getRefreshToken(id);

--- a/src/main/java/org/scoula/user/controller/UserController.java
+++ b/src/main/java/org/scoula/user/controller/UserController.java
@@ -45,4 +45,10 @@ public class UserController {
         return CommonResponseDTO.success("임시 비밀번호가 발급되었습니다.", tempPassword);
     }
 
+    @PutMapping("/withdrwal")
+    public CommonResponseDTO<Void> withdrawal(@RequestHeader("Authorization") String token) {
+        userService.withdrawal(token);
+        return CommonResponseDTO.success("회원 탈퇴가 완료되었습니다.");
+    }
+
 }

--- a/src/main/java/org/scoula/user/mapper/UserMapper.java
+++ b/src/main/java/org/scoula/user/mapper/UserMapper.java
@@ -13,5 +13,5 @@ public interface UserMapper {
     String findNicknameById(Long id);
     void updatePassword(User user); // 비밀번호 재발급
     void insertUserChallengeSummary(@Param("userId") Long userId);
-
+    void updateIsActive(@Param("id") Long id);
 }

--- a/src/main/java/org/scoula/user/service/UserService.java
+++ b/src/main/java/org/scoula/user/service/UserService.java
@@ -11,4 +11,7 @@ public interface UserService {
     TokenResponseDTO login(UserLoginRequestDTO req);
     TokenResponseDTO refresh(String refreshToken);
     String resetPassword(String email);
+    void logout(String token);
+    void withdrawal(String token);
+
 }

--- a/src/main/java/org/scoula/user/service/UserServiceImpl.java
+++ b/src/main/java/org/scoula/user/service/UserServiceImpl.java
@@ -19,6 +19,7 @@ import org.scoula.user.util.NicknameGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -108,6 +109,12 @@ public class UserServiceImpl implements UserService {
         if (!encoder.matches(req.getPassword(), u.getPassword())) {
             throw new InvalidPasswordException();
         }
+
+        // 계정이 활성화 상태인지 확인합니다.
+        if (!u.getIsActive()) {
+            throw new DisabledException("비활성화된 계정입니다.");
+        }
+
 
         String at = jwtUtil.generateAccessToken(u.getId(), u.getEmail());
         String rt = jwtUtil.generateRefreshToken(u.getId(), u.getEmail());

--- a/src/main/resources/org/scoula/security/account/mapper/UserDetailsMapper.xml
+++ b/src/main/resources/org/scoula/security/account/mapper/UserDetailsMapper.xml
@@ -16,14 +16,13 @@
         <result property="createdAt" column="created_at"/>
         <result property="updatedAt" column="updated_at"/>
         <result property="lastPwChangeAt" column="last_pw_change_at"/>
-<!--        <result property="isActive" column="is_active"/>-->
+        <result property="isActive" column="is_active"/>
     </resultMap>
 
     <select id="get" resultMap="userMap">
         SELECT
             id, email, password, user_name, phone_num, gender,
-            birthday, created_at, updated_at, last_pw_change_at
---         ,is_active
+            birthday, created_at, updated_at, last_pw_change_at, is_active
         FROM user
         WHERE email = #{email}
     </select>

--- a/src/main/resources/org/scoula/user/mapper/UserMapper.xml
+++ b/src/main/resources/org/scoula/user/mapper/UserMapper.xml
@@ -34,4 +34,9 @@
         VALUES (#{userId}, 0, 0, 0.00)
     </insert>
 
+    <update id="updateIsActive">
+        UPDATE user
+        SET is_active = false
+        WHERE id = #{id}
+    </update>
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
**로그아웃 및 회원 탈퇴 기능 구현과 JWT 블랙리스트 검증 로직을 추가합니다.**

- 로그인 시 비활성화된 계정을 필터링하고, 로그아웃 시 Access Token을 블랙리스트에 등록하여 즉시 무효화하는 기능을 구현했습니다. 또한, 테스트 편의성을 위한 Swagger API 엔드포인트를 추가하고 관련 데이터베이스 스키마를 수정했습니다

## 📖 작업 내용 
**로그아웃 기능 구현**

- 로그아웃 요청 시, Redis에 저장된 Refresh Token을 삭제합니다.
- 기존 Access Token은 남은 유효시간(TTL)을 계산하여 Redis 블랙리스트에 추가합니다.

**회원 탈퇴 (Soft-delete) 기능 구현**

- 회원 탈퇴 시 user 테이블의 is_active 컬럼을 false로 업데이트합니다.
- Spring Security의 UserDetails.isEnabled() 메소드를 is_active 컬럼과 연동하여, 비활성화된 사용자의 로그인을 차단하도록 구현했습니다.

**JWT 블랙리스트 검증 로직 추가**

- JwtAuthenticationFilter에 로그아웃 처리된 Access Token(블랙리스트에 등록된 토큰)이 들어올 경우, 요청을 거부하는 검증 로직을 추가하고 활성화했습니다. (BlackListException 처리 포함)

**데이터베이스 스키마 수정**

- user 테이블에 인증서용 간편 비밀번호 저장을 위한 auth_pw 컬럼(VARBINARY 타입)을 추가했습니다.
- UserMapper.xml에 is_active 컬럼 매핑을 추가하여 NullPointerException 문제를 해결했습니다.

**테스트 및 개발 편의성 개선**

- Swagger 문서화를 위한 가상 POST /api/auth/login 엔드포인트를 AuthController에 추가했습니다.
- UserService의 테스트용 로그인 로직에 회원 탈퇴(비활성화) 여부를 확인하는 코드를 추가했습니다.
## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
closes #105