### PR TITLE
Feat/#121 agree service

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -58,9 +58,9 @@ CREATE TABLE `investment_types` (
 DROP TABLE IF EXISTS `agree`;
 CREATE TABLE agree (
                        `id` BIGINT NOT NULL,
-                       `open_banking_agreed` BOOLEAN NOT NULL,
-                       `personal_info_agreed` BOOLEAN NOT NULL,
-                       `ars_agreed` BOOLEAN NOT NULL,
+                       `open_banking_agreed` BOOLEAN DEFAULT false,
+                       `personal_info_agreed` BOOLEAN DEFAULT false,
+                       `ars_agreed` BOOLEAN DEFAULT false,
                        `open_banking_agreed_at` DATETIME NULL,
                        `personal_info_agreed_at` DATETIME NULL,
                        `ars_agreed_at` DATETIME NULL,

--- a/database.sql
+++ b/database.sql
@@ -56,14 +56,19 @@ CREATE TABLE `investment_types` (
 
 -- 4. 유저의 약관 동의
 DROP TABLE IF EXISTS `agree`;
-CREATE TABLE `agree` (
-                         `id` BIGINT NOT NULL,
-                         `login_agreed` BOOLEAN NOT NULL,
-                         `mydata_agreed` BOOLEAN NOT NULL,
-                         `login_agreed_at` DATETIME,
-                         `mydata_agreed_at` DATETIME,
-                         PRIMARY KEY (`id`),
-                         FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE
+CREATE TABLE agree (
+                       `id` BIGINT NOT NULL,
+                       `open_banking_agreed` BOOLEAN NOT NULL,
+                       `personal_info_agreed` BOOLEAN NOT NULL,
+                       `ars_agreed` BOOLEAN NOT NULL,
+                       `open_banking_agreed_at` DATETIME NULL,
+                       `personal_info_agreed_at` DATETIME NULL,
+                       `ars_agreed_at` DATETIME NULL,
+                       PRIMARY KEY (id),
+
+                       CONSTRAINT fk_agree_user_id FOREIGN KEY (id) REFERENCES user (id)
+                               ON DELETE CASCADE
+                               ON UPDATE CASCADE
 );
 
 -- 5. mydata 정보

--- a/src/main/java/org/scoula/agree/controller/AgreeController.java
+++ b/src/main/java/org/scoula/agree/controller/AgreeController.java
@@ -1,0 +1,50 @@
+package org.scoula.agree.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.scoula.agree.service.AgreeService;
+import org.scoula.common.dto.CommonResponseDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@Log4j2
+@Api(tags="약관동의API", description = "agree controller")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/agree")
+public class AgreeController {
+
+    final private AgreeService agreeService;
+
+    @ApiOperation(value="약관동의정보 생성", notes="유저별로 약관동의와 관련한 기본정보들을 생성합니다.")
+    @PostMapping("")
+    public ResponseEntity<CommonResponseDTO<String>> createAgree(@RequestParam Long userId) {
+        agreeService.createAgree(userId);
+        return ResponseEntity.ok(CommonResponseDTO.success("약관동의정보 생성 성공"));
+    }
+
+    @ApiOperation(value="오픈뱅킹약관 동의", notes="오픈뱅킹약관에 동의한 내용을 저장합니다.")
+    @PutMapping("/openbanking")
+    public ResponseEntity<CommonResponseDTO<String>> agreeOpenbanking(@RequestParam Long userId) {
+        agreeService.updateOpenBankingAgree(userId);
+        return ResponseEntity.ok(CommonResponseDTO.success("오픈뱅킹약관 동의 성공"));
+    }
+
+    @ApiOperation(value="개인정보약관 동의", notes="개인정보약관에 동의한 내용을 저장합니다.")
+    @PutMapping("/personalInfo")
+    public ResponseEntity<CommonResponseDTO<String>> agreePersonalInfo(@RequestParam Long userId) {
+        agreeService.updatePersonalInfoAgree(userId);
+        return ResponseEntity.ok(CommonResponseDTO.success("개인정보약관 동의 성공"));
+    }
+
+    @ApiOperation(value="ars 동의", notes="ars약관에 동의한 내용을 저장합니다.")
+    @PutMapping("/ars")
+    public ResponseEntity<CommonResponseDTO<String>> agreeArs(@RequestParam Long userId) {
+        agreeService.updateArsAgree(userId);
+        return ResponseEntity.ok(CommonResponseDTO.success("ars약관 동의 성공"));
+    }
+
+}

--- a/src/main/java/org/scoula/agree/domain/AgreeVO.java
+++ b/src/main/java/org/scoula/agree/domain/AgreeVO.java
@@ -1,0 +1,16 @@
+package org.scoula.agree.domain;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class AgreeVO {
+    private Long id; // user_id
+    private boolean openBankingAgreed;
+    private boolean personalInfoAgreed;
+    private boolean arsAgreed;
+    private LocalDateTime openBankingAgreedAt;
+    private LocalDateTime personalInfoAgreedAt;
+    private LocalDateTime arsAgreedAt;
+}

--- a/src/main/java/org/scoula/agree/dto/AgreeDTO.java
+++ b/src/main/java/org/scoula/agree/dto/AgreeDTO.java
@@ -1,0 +1,48 @@
+package org.scoula.agree.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.scoula.agree.domain.AgreeVO;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AgreeDTO {
+    private Long id;
+    private boolean openBankingAgreed;
+    private boolean personalInfoAgreed;
+    private boolean arsAgreed;
+    private LocalDateTime openBankingAgreedAt;
+    private LocalDateTime personalInfoAgreedAt;
+    private LocalDateTime arsAgreedAt;
+
+
+    public static AgreeDTO of(AgreeVO vo) {
+        return AgreeDTO.builder()
+                .id(vo.getId())
+                .openBankingAgreed(vo.isOpenBankingAgreed())
+                .personalInfoAgreed(vo.isPersonalInfoAgreed())
+                .arsAgreed(vo.isArsAgreed())
+                .openBankingAgreedAt(vo.getOpenBankingAgreedAt())
+                .personalInfoAgreedAt(vo.getPersonalInfoAgreedAt())
+                .arsAgreedAt(vo.getArsAgreedAt())
+                .build();
+    }
+
+    public AgreeVO toVO() {
+        AgreeVO vo = new AgreeVO();
+        vo.setId(this.id);
+        vo.setOpenBankingAgreed(this.openBankingAgreed);
+        vo.setPersonalInfoAgreed(this.personalInfoAgreed);
+        vo.setArsAgreed(this.arsAgreed);
+        vo.setOpenBankingAgreedAt(this.openBankingAgreedAt);
+        vo.setPersonalInfoAgreedAt(this.personalInfoAgreedAt);
+        vo.setArsAgreedAt(this.arsAgreedAt);
+        return vo;
+    }
+}

--- a/src/main/java/org/scoula/agree/mapper/AgreeMapper.java
+++ b/src/main/java/org/scoula/agree/mapper/AgreeMapper.java
@@ -1,0 +1,14 @@
+package org.scoula.agree.mapper;
+
+import org.scoula.agree.domain.AgreeVO;
+
+public interface AgreeMapper {
+    void insert(Long userId);
+    //오픈뱅킹동의정보 true로
+    void updateOpenBanking(AgreeVO vo);
+    //개인정보동의정보 true로
+    void updatePersonalInfo(AgreeVO vo);
+    //ars동의정보 true로
+    void updateArs(AgreeVO vo);
+
+}

--- a/src/main/java/org/scoula/agree/service/AgreeService.java
+++ b/src/main/java/org/scoula/agree/service/AgreeService.java
@@ -1,0 +1,14 @@
+package org.scoula.agree.service;
+
+import org.scoula.agree.domain.AgreeVO;
+
+public interface AgreeService {
+    //약관동의정보 만들기
+    void createAgree(Long id);
+    //오픈뱅킹동의정보 true로
+    void updateOpenBankingAgree(Long userId);
+    //개인정보동의정보 true로
+    void updatePersonalInfoAgree(Long userId);
+    //ars동의정보 true로
+    void updateArsAgree(Long userId);
+}

--- a/src/main/java/org/scoula/agree/service/AgreeServiceImpl.java
+++ b/src/main/java/org/scoula/agree/service/AgreeServiceImpl.java
@@ -1,0 +1,48 @@
+package org.scoula.agree.service;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.agree.dto.AgreeDTO;
+import org.scoula.agree.mapper.AgreeMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AgreeServiceImpl implements AgreeService {
+
+    final private AgreeMapper agreeMapper;
+
+    @Override
+    public void createAgree(Long id) {
+        agreeMapper.insert(id);
+    }
+
+    @Override
+    public void updateOpenBankingAgree(Long userId) {
+        AgreeDTO agreeDTO=AgreeDTO.builder()
+                .id(userId)
+                .openBankingAgreed(true)
+                .build();
+
+        agreeMapper.updateOpenBanking(agreeDTO.toVO());
+    }
+
+    @Override
+    public void updatePersonalInfoAgree(Long userId) {
+        AgreeDTO agreeDTO=AgreeDTO.builder()
+                .id(userId)
+                .personalInfoAgreed(true)
+                .build();
+
+        agreeMapper.updatePersonalInfo(agreeDTO.toVO());
+    }
+
+    @Override
+    public void updateArsAgree(Long userId) {
+        AgreeDTO agreeDTO=AgreeDTO.builder()
+                .id(userId)
+                .arsAgreed(true)
+                .build();
+
+        agreeMapper.updateArs(agreeDTO.toVO());
+    }
+}

--- a/src/main/java/org/scoula/alarm/controller/AlarmController.java
+++ b/src/main/java/org/scoula/alarm/controller/AlarmController.java
@@ -22,7 +22,7 @@ public class AlarmController {
     final private AlarmService alarmService;
 
     @ApiOperation(value="알람 조회", notes="현재 존재하는 알람들을 조회합니다.")
-    @PostMapping("/userId={userId}")
+    @GetMapping("/userId={userId}")
     public ResponseEntity<CommonResponseDTO<List<AlarmDTO>>> getAlarm(@PathVariable Long userId) {
         List<AlarmDTO> alarmDTO=alarmService.getAlarms(userId);
         return ResponseEntity.ok(CommonResponseDTO.success("알람 조회 성공", alarmDTO));

--- a/src/main/java/org/scoula/avatar/controller/AvatarController.java
+++ b/src/main/java/org/scoula/avatar/controller/AvatarController.java
@@ -24,6 +24,7 @@ public class AvatarController {
     final private AvatarService avatarService;
 
     //아바타 생성
+    //swagger 테스트용
     @ApiOperation(value="아바타 생성", notes="아바타를 생성합니다.")
     @PostMapping("/userId={userId}")
     public ResponseEntity<CommonResponseDTO<String>> insertAvatar(@PathVariable Long userId) {

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -38,7 +38,8 @@ import javax.sql.DataSource;
         "org.scoula.card.mapper",
         "org.scoula.alarm.mapper",
         "org.scoula.monthreport.mapper",
-        "org.scoula.coin.mapper"
+        "org.scoula.coin.mapper",
+        "org.scoula.agree.mapper",
 })
 @ComponentScan(basePackages = {
         "org.scoula.security",
@@ -68,6 +69,7 @@ import javax.sql.DataSource;
         "org.scoula.monthreport.service",
         "org.scoula.monthreport.scheduler",
         "org.scoula.monthreport.util",
+        "org.scoula.agree.service",
         })
 @EnableTransactionManagement
 public class RootConfig {

--- a/src/main/java/org/scoula/config/ServletConfig.java
+++ b/src/main/java/org/scoula/config/ServletConfig.java
@@ -40,6 +40,7 @@ import java.util.List;
         "org.scoula.card.exception",
         "org.scoula.alarm.controller",
         "org.scoula.monthreport.controller",
+        "org.scoula.agree.controller",
 })
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/java/org/scoula/user/service/UserServiceImpl.java
+++ b/src/main/java/org/scoula/user/service/UserServiceImpl.java
@@ -1,6 +1,8 @@
 package org.scoula.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.scoula.agree.mapper.AgreeMapper;
+import org.scoula.avatar.mapper.AvatarMapper;
 import org.scoula.coin.mapper.CoinMapper;
 import org.scoula.common.redis.RedisService;
 import org.scoula.user.domain.User;
@@ -38,7 +40,8 @@ public class UserServiceImpl implements UserService {
     private final RedisService redisService;
     private final PasswordEncoder encoder;
     private final NicknameGenerator nicknameGenerator;
-
+    private final AvatarMapper avatarMapper;
+    private final AgreeMapper agreeMapper;
 
     private final Logger log = LoggerFactory.getLogger(UserService.class);
 
@@ -94,6 +97,12 @@ public class UserServiceImpl implements UserService {
 
         // 4. 챌린지 요약 초기화
         userMapper.insertUserChallengeSummary(user.getId());
+
+        // 5. 내 아바타 초기화
+        avatarMapper.insertAvatar(user.getId());
+
+        // 6. 동의정보 초기화
+        agreeMapper.insert(user.getId());
 
         return UserResponseDTO.builder()
                 .id(user.getId())

--- a/src/main/resources/org/scoula/agree/mapper/AgreeMapper.xml
+++ b/src/main/resources/org/scoula/agree/mapper/AgreeMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.scoula.agree.mapper.AgreeMapper">
+
+    <insert id="insert">
+        INSERT INTO agree(id) VALUES (#{userId});
+    </insert>
+
+    <update id="updateOpenBanking" parameterType="org.scoula.agree.domain.AgreeVO">
+        UPDATE agree SET open_banking_agreed=#{openBankingAgreed}, open_banking_agreed_at=Now() where id=#{id}
+    </update>
+
+    <update id="updatePersonalInfo" parameterType="org.scoula.agree.domain.AgreeVO">
+        UPDATE agree SET personal_info_agreed=#{personalInfoAgreed}, personal_info_agreed_at=Now() where id=#{id}
+    </update>
+
+    <update id="updateArs" parameterType="org.scoula.agree.domain.AgreeVO">
+        UPDATE agree SET ars_agreed=#{arsAgreed}, ars_agreed_at=Now() where id=#{id}
+    </update>
+
+</mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
사용자 회원가입 시 약관 동의 정보를 함께 생성하고, 각 약관에 개별적으로 동의할 수 있는 API를 구현했습니다
## 📖 작업 내용 
- **회원가입 시 유저테이블 생성**
UserService에 AgreeMapper를 이용하여 user테이블 생성과 동시에 agree테이블도 생성되도록 했습니다.

- **약관 동의 기능 구현**
각 약관(오픈뱅킹, 개인정보, ARS)에 개별적으로 동의 처리하는 API 엔드포인트 3종을 추가했습니다.
## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
closes #121 