### PR TITLE
feat: 챌린지 공통/코인 랭킹 기능 구현

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -512,7 +512,7 @@ CREATE TABLE `user_challenge_summary` (
                                           FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE
 );
 
--- 5. 챌린지 랭킹
+-- 5. 챌린지 랭킹 (실시간)
 DROP TABLE IF EXISTS `challenge_rank`;
 CREATE TABLE `challenge_rank` (
                                   `ID` BIGINT NOT NULL AUTO_INCREMENT,
@@ -523,6 +523,56 @@ CREATE TABLE `challenge_rank` (
                                   PRIMARY KEY (`ID`),
                                   FOREIGN KEY (`user_challenge_id`) REFERENCES `user_challenge`(`ID`) ON DELETE CASCADE
 );
+
+
+-- 6. 챌린지 랭킹 스냅샷 (월별 최종 랭킹)
+DROP TABLE IF EXISTS `challenge_rank_snapshot`;
+CREATE TABLE `challenge_rank_snapshot` (
+                                           `id` BIGINT NOT NULL AUTO_INCREMENT,
+                                           `user_challenge_id` BIGINT NOT NULL,
+                                           `month` VARCHAR(7) NOT NULL COMMENT '예: 2025-08',
+                                           `rank` INT NOT NULL,
+                                           `progress_rate` DECIMAL(5,2) NOT NULL DEFAULT 0,
+                                           `is_checked` TINYINT(1) NOT NULL DEFAULT 0,
+                                           `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+                                           PRIMARY KEY (`id`),
+                                            FOREIGN KEY (`user_challenge_id`) REFERENCES `user_challenge`(`ID`) ON DELETE CASCADE
+);
+
+
+-- 7. 챌린지 누적 포인트 랭킹 (실시간)
+DROP TABLE IF EXISTS `challenge_coin_rank`;
+CREATE TABLE `challenge_coin_rank` (
+                                       `id` BIGINT NOT NULL AUTO_INCREMENT,
+                                       `user_id` BIGINT NOT NULL,
+                                       `month` VARCHAR(7) NOT NULL COMMENT '예: 2025-08',
+                                       `rank` INT NOT NULL,
+                                       `cumulative_point` BIGINT NOT NULL,
+                                       `challenge_count` INT NOT NULL,
+                                       `updated_at` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                                       PRIMARY KEY (`id`),
+                                       UNIQUE KEY `uniq_user_month` (`user_id`, `month`),
+                                       FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
+) ;
+
+-- 8. 챌린지 누적 포인트 랭킹 스냅샷 (월별 최종 랭킹)
+DROP TABLE IF EXISTS `challenge_coin_rank_snapshot`;
+CREATE TABLE `challenge_coin_rank_snapshot` (
+                                    `id` BIGINT NOT NULL AUTO_INCREMENT,
+                                    `user_id` BIGINT NOT NULL,
+                                    `month` VARCHAR(7) NOT NULL COMMENT '예: 2025-08',
+                                    `rank` INT NOT NULL,
+                                    `cumulative_point` BIGINT NOT NULL,
+                                    `challenge_count` INT NOT NULL,
+                                    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
+                                    PRIMARY KEY (`id`),
+                                    UNIQUE KEY `uniq_user_month` (`user_id`, `month`),
+                                    FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
+) ;
+
+
+
+
 
 
 -- CONTENT

--- a/src/main/java/org/scoula/challenge/rank/controller/ChallengeCoinRankController.java
+++ b/src/main/java/org/scoula/challenge/rank/controller/ChallengeCoinRankController.java
@@ -1,0 +1,33 @@
+package org.scoula.challenge.rank.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.challenge.rank.dto.ChallengeCoinRankResponseDTO;
+import org.scoula.challenge.rank.dto.ChallengeCoinRankSnapshotResponseDTO;
+import org.scoula.challenge.rank.service.ChallengeCoinRankService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/challenge/rank/coin")
+@RequiredArgsConstructor
+public class ChallengeCoinRankController {
+
+    private final ChallengeCoinRankService rankService;
+
+    @GetMapping
+    public List<ChallengeCoinRankResponseDTO> getCoinRanking(@RequestParam Long userId) {
+        return rankService.getTop5WithMyRank(userId);
+    }
+
+    @GetMapping("/snapshot")
+    public List<ChallengeCoinRankSnapshotResponseDTO> getCoinRankSnapshot(@RequestParam String month, @RequestParam Long userId) {
+        return rankService.getTop5SnapshotWithMyRank(month, userId);
+    }
+
+    @PatchMapping("/snapshot/check")
+    public void markCoinRankSnapshotChecked(@RequestParam String month, @RequestParam Long userId) {
+        rankService.markSnapshotAsChecked(month, userId);
+    }
+
+}

--- a/src/main/java/org/scoula/challenge/rank/controller/ChallengeRankController.java
+++ b/src/main/java/org/scoula/challenge/rank/controller/ChallengeRankController.java
@@ -1,0 +1,32 @@
+package org.scoula.challenge.rank.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.challenge.rank.dto.ChallengeRankResponseDTO;
+import org.scoula.challenge.rank.dto.ChallengeRankSnapshotResponseDTO;
+import org.scoula.challenge.rank.service.ChallengeRankService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/challenge/rank")
+@RequiredArgsConstructor
+public class ChallengeRankController {
+
+    private final ChallengeRankService rankService;
+
+    @GetMapping("/{challengeId}")
+    public List<ChallengeRankResponseDTO> getCurrentRank(@PathVariable Long challengeId) {
+        return rankService.getCurrentRank(challengeId);
+    }
+
+    @PostMapping("/{challengeId}/refresh")
+    public void updateRank(@PathVariable Long challengeId) {
+        rankService.updateCurrentRanks(challengeId);
+    }
+
+    @GetMapping("/snapshot")
+    public List<ChallengeRankSnapshotResponseDTO> getSnapshot(@RequestParam String month) {
+        return rankService.getRankSnapshot(month);
+    }
+}

--- a/src/main/java/org/scoula/challenge/rank/controller/ChallengeRankTestController.java
+++ b/src/main/java/org/scoula/challenge/rank/controller/ChallengeRankTestController.java
@@ -1,0 +1,31 @@
+package org.scoula.challenge.rank.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.challenge.rank.service.ChallengeCoinRankService;
+import org.scoula.challenge.rank.service.ChallengeRankService;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@RestController
+@RequestMapping("/api/challenge/rank/test")
+@RequiredArgsConstructor
+public class ChallengeRankTestController {
+
+    private final ChallengeRankService challengeRankService;
+    private final ChallengeCoinRankService coinRankService;
+
+    // 공통 챌린지 랭킹 스냅샷 수동 생성
+    @PostMapping("/common/snapshot")
+    public void snapshotCommonRank(@RequestParam(required = false) String month) {
+        String targetMonth = month != null ? month : LocalDate.now().minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        challengeRankService.snapshotMonthlyRanks(targetMonth);
+    }
+
+    // 누적 코인 랭킹 수동 생성
+    @PostMapping("/coin/snapshot")
+    public void snapshotCoinRank() {
+        coinRankService.calculateAndSaveRanks();
+    }
+}

--- a/src/main/java/org/scoula/challenge/rank/dto/ChallengeCoinRankResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/rank/dto/ChallengeCoinRankResponseDTO.java
@@ -1,0 +1,16 @@
+package org.scoula.challenge.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ChallengeCoinRankResponseDTO {
+    private Long userId;
+    private String nickname;
+    private int rank;
+    private long cumulativePoint;
+    private int challengeCount;
+}

--- a/src/main/java/org/scoula/challenge/rank/dto/ChallengeCoinRankSnapshotResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/rank/dto/ChallengeCoinRankSnapshotResponseDTO.java
@@ -1,0 +1,19 @@
+package org.scoula.challenge.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeCoinRankSnapshotResponseDTO {
+    private Long id;             // snapshot row id
+    private Long userId;         // 유저 ID
+    private String nickname;     // 유저 닉네임
+    private int rank;            // 랭킹
+    private long totalCoin;      // 누적 포인트
+    private String month;        // YYYY-MM
+}

--- a/src/main/java/org/scoula/challenge/rank/dto/ChallengeRankResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/rank/dto/ChallengeRankResponseDTO.java
@@ -1,0 +1,12 @@
+package org.scoula.challenge.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ChallengeRankResponseDTO {
+    private String nickname;
+    private int rank;
+    private int actualValue;
+}

--- a/src/main/java/org/scoula/challenge/rank/dto/ChallengeRankSnapshotResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/rank/dto/ChallengeRankSnapshotResponseDTO.java
@@ -1,0 +1,14 @@
+package org.scoula.challenge.rank.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ChallengeRankSnapshotResponseDTO {
+    private String nickname;
+    private int rank;
+    private int actualValue;
+    private String month;
+    private boolean isChecked;
+}

--- a/src/main/java/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.java
+++ b/src/main/java/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.java
@@ -1,0 +1,37 @@
+package org.scoula.challenge.rank.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.scoula.challenge.rank.dto.ChallengeCoinRankResponseDTO;
+import org.scoula.challenge.rank.dto.ChallengeCoinRankSnapshotResponseDTO;
+
+import java.util.List;
+
+public interface ChallengeCoinRankMapper {
+
+    // 현재 랭킹 조회용
+    List<ChallengeCoinRankResponseDTO> getTop5CoinRank(@Param("month") String month);
+
+    ChallengeCoinRankResponseDTO getMyCoinRank(@Param("userId") Long userId, @Param("month") String month);
+
+    void insertOrUpdateRank(
+            @Param("userId") Long userId,
+            @Param("month") String month,
+            @Param("cumulativePoint") Long cumulativePoint,
+            @Param("challengeCount") int challengeCount,
+            @Param("rank") int rank
+    );
+
+    List<Long> getAllUserIdsInMonth(@Param("month") String month);
+
+    // 누적 포인트 랭킹 스냅샷 조회 (Top 5 + 나)
+    List<ChallengeCoinRankSnapshotResponseDTO> getCoinRankSnapshotTop5WithMyRank(
+            @Param("month") String month,
+            @Param("userId") Long userId
+    );
+
+    // 랭킹 결과 확인 여부(is_checked) 업데이트
+    void markCoinRankSnapshotChecked(
+            @Param("month") String month,
+            @Param("userId") Long userId
+    );
+}

--- a/src/main/java/org/scoula/challenge/rank/mapper/ChallengeRankMapper.java
+++ b/src/main/java/org/scoula/challenge/rank/mapper/ChallengeRankMapper.java
@@ -1,0 +1,32 @@
+package org.scoula.challenge.rank.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.scoula.challenge.rank.dto.ChallengeRankResponseDTO;
+import org.scoula.challenge.rank.dto.ChallengeRankSnapshotResponseDTO;
+import org.scoula.challenge.rank.util.ChallengeParticipantProvider.ParticipantInfo;
+
+import java.util.List;
+
+@Mapper
+public interface ChallengeRankMapper {
+
+    List<ChallengeRankResponseDTO> getCurrentChallengeRanks(@Param("challengeId") Long challengeId);
+
+    void clearCurrentChallengeRanks(@Param("challengeId") Long challengeId);
+
+    void insertChallengeRank(@Param("userChallengeId") Long userChallengeId,
+                             @Param("rank") int rank,
+                             @Param("actualValue") int actualValue);
+
+    List<ChallengeRankSnapshotResponseDTO> getChallengeRankSnapshots(@Param("month") String month);
+
+    void insertChallengeRankSnapshot(@Param("userChallengeId") Long userChallengeId,
+                                     @Param("rank") int rank,
+                                     @Param("actualValue") int actualValue,
+                                     @Param("month") String month);
+
+    List<ParticipantInfo> getParticipantsSortedByActualValue(@Param("challengeId") Long challengeId);
+
+    List<ParticipantInfo> getParticipantsSortedByActualValueInMonth(@Param("month") String month);
+}

--- a/src/main/java/org/scoula/challenge/rank/scheduler/ChallengeCoinRankScheduler.java
+++ b/src/main/java/org/scoula/challenge/rank/scheduler/ChallengeCoinRankScheduler.java
@@ -1,0 +1,23 @@
+package org.scoula.challenge.rank.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.scoula.challenge.rank.service.ChallengeCoinRankService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeCoinRankScheduler {
+
+    private final ChallengeCoinRankService rankService;
+
+    // 매월 1일 05:00에 실행
+    @Scheduled(cron = "0 0 5 1 * *", zone = "Asia/Seoul")
+    public void calculateMonthlyCoinRank() {
+        log.info("[Scheduler] 월간 누적 포인트 랭킹 산정 시작");
+        rankService.calculateAndSaveRanks();
+        log.info("[Scheduler] 월간 누적 포인트 랭킹 산정 완료");
+    }
+}

--- a/src/main/java/org/scoula/challenge/rank/scheduler/ChallengeRankScheduler.java
+++ b/src/main/java/org/scoula/challenge/rank/scheduler/ChallengeRankScheduler.java
@@ -1,0 +1,22 @@
+package org.scoula.challenge.rank.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.challenge.rank.service.ChallengeRankService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@RequiredArgsConstructor
+public class ChallengeRankScheduler {
+
+    private final ChallengeRankService rankService;
+
+    @Scheduled(cron = "0 0 5 1 * ?") // 매월 1일 새벽 5시
+    public void generateMonthlyChallengeRankSnapshot() {
+        String month = LocalDate.now().minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        rankService.snapshotMonthlyRanks(month);
+    }
+}

--- a/src/main/java/org/scoula/challenge/rank/service/ChallengeCoinRankService.java
+++ b/src/main/java/org/scoula/challenge/rank/service/ChallengeCoinRankService.java
@@ -1,0 +1,15 @@
+package org.scoula.challenge.rank.service;
+
+import org.scoula.challenge.rank.dto.ChallengeCoinRankResponseDTO;
+import org.scoula.challenge.rank.dto.ChallengeCoinRankSnapshotResponseDTO;
+
+import java.util.List;
+
+public interface ChallengeCoinRankService {
+    List<ChallengeCoinRankResponseDTO> getTop5WithMyRank(Long userId);
+
+    List<ChallengeCoinRankSnapshotResponseDTO> getTop5SnapshotWithMyRank(String month, Long userId); // 추가
+    void markSnapshotAsChecked(String month, Long userId); // 추가
+
+    void calculateAndSaveRanks(); // 스케줄러용
+}

--- a/src/main/java/org/scoula/challenge/rank/service/ChallengeCoinRankServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/rank/service/ChallengeCoinRankServiceImpl.java
@@ -1,0 +1,62 @@
+package org.scoula.challenge.rank.service;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.challenge.rank.dto.ChallengeCoinRankResponseDTO;
+import org.scoula.challenge.rank.dto.ChallengeCoinRankSnapshotResponseDTO;
+import org.scoula.challenge.rank.mapper.ChallengeCoinRankMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeCoinRankServiceImpl implements ChallengeCoinRankService {
+
+    private final ChallengeCoinRankMapper rankMapper;
+
+    @Override
+    public List<ChallengeCoinRankResponseDTO> getTop5WithMyRank(Long userId) {
+        String currentMonth = LocalDate.now().withDayOfMonth(1).toString().substring(0, 7);
+        List<ChallengeCoinRankResponseDTO> top5 = rankMapper.getTop5CoinRank(currentMonth);
+        ChallengeCoinRankResponseDTO mine = rankMapper.getMyCoinRank(userId, currentMonth);
+
+        if (mine != null && top5.stream().noneMatch(r -> r.getUserId().equals(userId))) {
+            top5.add(mine);
+        }
+
+        return top5;
+    }
+
+    @Override
+    public void calculateAndSaveRanks() {
+        String month = LocalDate.now().minusMonths(1).withDayOfMonth(1).toString().substring(0, 7);
+        List<Long> userIds = rankMapper.getAllUserIdsInMonth(month);
+
+        List<ChallengeCoinRankResponseDTO> ranks = userIds.stream().map(userId -> {
+                    ChallengeCoinRankResponseDTO dto = rankMapper.getMyCoinRank(userId, month);
+                    return dto != null ? dto : null;
+                }).filter(r -> r != null)
+                .sorted(Comparator.comparingLong(ChallengeCoinRankResponseDTO::getCumulativePoint).reversed()
+                        .thenComparingInt(ChallengeCoinRankResponseDTO::getChallengeCount).reversed())
+                .collect(Collectors.toList());
+
+        for (int i = 0; i < ranks.size(); i++) {
+            ChallengeCoinRankResponseDTO r = ranks.get(i);
+            rankMapper.insertOrUpdateRank(r.getUserId(), month, r.getCumulativePoint(), r.getChallengeCount(), i + 1);
+        }
+    }
+
+    @Override
+    public List<ChallengeCoinRankSnapshotResponseDTO> getTop5SnapshotWithMyRank(String month, Long userId) {
+        return rankMapper.getCoinRankSnapshotTop5WithMyRank(month, userId);
+    }
+
+    @Override
+    public void markSnapshotAsChecked(String month, Long userId) {
+        rankMapper.markCoinRankSnapshotChecked(month, userId);
+    }
+
+}

--- a/src/main/java/org/scoula/challenge/rank/service/ChallengeRankService.java
+++ b/src/main/java/org/scoula/challenge/rank/service/ChallengeRankService.java
@@ -1,0 +1,17 @@
+package org.scoula.challenge.rank.service;
+
+import org.scoula.challenge.rank.dto.ChallengeRankResponseDTO;
+import org.scoula.challenge.rank.dto.ChallengeRankSnapshotResponseDTO;
+
+import java.util.List;
+
+public interface ChallengeRankService {
+
+    List<ChallengeRankResponseDTO> getCurrentRank(Long challengeId);
+
+    void updateCurrentRanks(Long challengeId);
+
+    void snapshotMonthlyRanks(String month);
+
+    List<ChallengeRankSnapshotResponseDTO> getRankSnapshot(String month);
+}

--- a/src/main/java/org/scoula/challenge/rank/service/ChallengeRankServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/rank/service/ChallengeRankServiceImpl.java
@@ -1,0 +1,52 @@
+package org.scoula.challenge.rank.service;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.challenge.rank.dto.ChallengeRankResponseDTO;
+import org.scoula.challenge.rank.dto.ChallengeRankSnapshotResponseDTO;
+import org.scoula.challenge.rank.mapper.ChallengeRankMapper;
+import org.scoula.challenge.rank.util.ChallengeParticipantProvider;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeRankServiceImpl implements ChallengeRankService {
+
+    private final ChallengeRankMapper rankMapper;
+
+    private final ChallengeParticipantProvider participantProvider;
+
+    @Override
+    public List<ChallengeRankResponseDTO> getCurrentRank(Long challengeId) {
+        return rankMapper.getCurrentChallengeRanks(challengeId);
+    }
+
+    @Override
+    public void updateCurrentRanks(Long challengeId) {
+        List<ChallengeParticipantProvider.ParticipantInfo> participants = participantProvider.getParticipantsSortedByActualValue(challengeId);
+        rankMapper.clearCurrentChallengeRanks(challengeId);
+
+        int rank = 1;
+        for (ChallengeParticipantProvider.ParticipantInfo p : participants) {
+            rankMapper.insertChallengeRank(p.userChallengeId(), rank++, p.actualValue());
+        }
+    }
+
+    @Override
+    public void snapshotMonthlyRanks(String month) {
+        List<ChallengeParticipantProvider.ParticipantInfo> participants = participantProvider.getParticipantsSortedByActualValueInMonth(month);
+
+        int rank = 1;
+        for (ChallengeParticipantProvider.ParticipantInfo p : participants) {
+            rankMapper.insertChallengeRankSnapshot(p.userChallengeId(), rank++, p.actualValue(), month);
+        }
+    }
+
+    @Override
+    public List<ChallengeRankSnapshotResponseDTO> getRankSnapshot(String month) {
+        return rankMapper.getChallengeRankSnapshots(month);
+    }
+}

--- a/src/main/java/org/scoula/challenge/rank/util/ChallengeParticipantProvider.java
+++ b/src/main/java/org/scoula/challenge/rank/util/ChallengeParticipantProvider.java
@@ -1,0 +1,14 @@
+package org.scoula.challenge.rank.util;
+
+import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+public interface ChallengeParticipantProvider {
+    List<ParticipantInfo> getParticipantsSortedByActualValue(Long challengeId);
+
+    List<ParticipantInfo> getParticipantsSortedByActualValueInMonth(String month);
+
+    record ParticipantInfo(Long userChallengeId, int actualValue) {}
+}

--- a/src/main/java/org/scoula/challenge/rank/util/ChallengeParticipantProviderImpl.java
+++ b/src/main/java/org/scoula/challenge/rank/util/ChallengeParticipantProviderImpl.java
@@ -1,0 +1,24 @@
+package org.scoula.challenge.rank.util;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.challenge.rank.mapper.ChallengeRankMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ChallengeParticipantProviderImpl implements ChallengeParticipantProvider {
+
+    private final ChallengeRankMapper challengeRankMapper;
+
+    @Override
+    public List<ParticipantInfo> getParticipantsSortedByActualValue(Long challengeId) {
+        return challengeRankMapper.getParticipantsSortedByActualValue(challengeId);
+    }
+
+    @Override
+    public List<ParticipantInfo> getParticipantsSortedByActualValueInMonth(String month) {
+        return challengeRankMapper.getParticipantsSortedByActualValueInMonth(month);
+    }
+}

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -40,6 +40,7 @@ import javax.sql.DataSource;
         "org.scoula.monthreport.mapper",
         "org.scoula.coin.mapper",
         "org.scoula.agree.mapper",
+        "org.scoula.challenge.rank.mapper"
 })
 @ComponentScan(basePackages = {
         "org.scoula.security",
@@ -70,6 +71,9 @@ import javax.sql.DataSource;
         "org.scoula.monthreport.scheduler",
         "org.scoula.monthreport.util",
         "org.scoula.agree.service",
+        "org.scoula.challenge.rank.scheduler",
+        "org.scoula.challenge.rank.service",
+        "org.scoula.challenge.rank.util"
         })
 @EnableTransactionManagement
 public class RootConfig {

--- a/src/main/java/org/scoula/config/ServletConfig.java
+++ b/src/main/java/org/scoula/config/ServletConfig.java
@@ -41,6 +41,7 @@ import java.util.List;
         "org.scoula.alarm.controller",
         "org.scoula.monthreport.controller",
         "org.scoula.agree.controller",
+        "org.scoula.challenge.rank.controller"
 })
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.xml
+++ b/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.scoula.challenge.rank.mapper.ChallengeCoinRankMapper">
+
+    <select id="getTop5CoinRank" resultType="org.scoula.challenge.rank.dto.ChallengeCoinRankResponseDTO">
+        SELECT u.id AS userId, us.nickname, cr.rank, cr.cumulative_point, cr.challenge_count
+        FROM challenge_coin_rank cr
+                 JOIN user u ON u.id = cr.user_id
+                 JOIN user_status us ON us.id = u.id
+        WHERE cr.month = #{month}
+        ORDER BY cr.rank ASC
+            LIMIT 5
+    </select>
+
+    <select id="getMyCoinRank" resultType="org.scoula.challenge.rank.dto.ChallengeCoinRankResponseDTO">
+        SELECT u.id AS userId, us.nickname, cr.rank, cr.cumulative_point, cr.challenge_count
+        FROM challenge_coin_rank cr
+                 JOIN user u ON u.id = cr.user_id
+                 JOIN user_status us ON us.id = u.id
+        WHERE cr.month = #{month}
+          AND cr.user_id = #{userId}
+    </select>
+
+    <select id="getAllUserIdsInMonth" resultType="long">
+        SELECT user_id
+        FROM challenge_coin_rank
+        WHERE month = #{month}
+    </select>
+
+    <insert id="insertOrUpdateRank">
+        INSERT INTO challenge_coin_rank (user_id, month, cumulative_point, challenge_count, rank, updated_at)
+        VALUES (#{userId}, #{month}, #{cumulativePoint}, #{challengeCount}, #{rank}, NOW())
+            ON DUPLICATE KEY UPDATE
+                                 cumulative_point = #{cumulativePoint},
+                                 challenge_count = #{challengeCount},
+                                 rank = #{rank},
+                                 updated_at = NOW()
+    </insert>
+
+    <select id="getCoinRankSnapshotTop5WithMyRank" resultType="org.scoula.challenge.rank.dto.ChallengeCoinRankSnapshotResponseDTO">
+        SELECT
+            cr.id, u.id as user_id, us.nickname, cr.rank, cr.total_coin, cr.month
+        FROM (
+                 SELECT * FROM challenge_coin_rank_snapshot
+                 WHERE month = #{month}
+                 ORDER BY rank ASC
+                     LIMIT 5
+             ) cr
+                 JOIN user u ON cr.user_id = u.id
+                 JOIN user_status us ON u.id = us.id
+
+        UNION ALL
+
+        SELECT
+            cr.id, u.id as user_id, us.nickname, cr.rank, cr.total_coin, cr.month
+        FROM challenge_coin_rank_snapshot cr
+                 JOIN user u ON cr.user_id = u.id
+                 JOIN user_status us ON u.id = us.id
+        WHERE cr.month = #{month} AND cr.user_id = #{userId}
+    </select>
+
+    <update id="markCoinRankSnapshotChecked">
+        UPDATE challenge_coin_rank_snapshot
+        SET is_checked = 1
+        WHERE month = #{month} AND user_id = #{userId}
+    </update>
+
+
+</mapper>

--- a/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeRankMapper.xml
+++ b/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeRankMapper.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.scoula.challenge.rank.mapper.ChallengeRankMapper">
+
+    <select id="getCurrentChallengeRanks" resultType="org.scoula.challenge.rank.dto.ChallengeRankResponseDTO">
+        SELECT us.nickname, cr.rank, uc.actual_value AS actualValue
+        FROM challenge_rank cr
+                 JOIN user_challenge uc ON cr.user_challenge_id = uc.id
+                 JOIN user_status us ON uc.user_id = us.id
+        WHERE uc.challenge_id = #{challengeId}
+        ORDER BY cr.rank
+    </select>
+
+    <delete id="clearCurrentChallengeRanks">
+        DELETE FROM challenge_rank
+        WHERE user_challenge_id IN (
+            SELECT id FROM user_challenge WHERE challenge_id = #{challengeId}
+        )
+    </delete>
+
+    <insert id="insertChallengeRank">
+        INSERT INTO challenge_rank (user_challenge_id, rank, progress_rate)
+        VALUES (#{userChallengeId}, #{rank}, 0)
+    </insert>
+
+    <select id="getChallengeRankSnapshots" resultType="org.scoula.challenge.rank.dto.ChallengeRankSnapshotResponseDTO">
+        SELECT us.nickname, crs.rank, uc.actual_value AS actualValue, crs.month, crs.is_checked AS isChecked
+        FROM challenge_rank_snapshot crs
+                 JOIN user_challenge uc ON crs.user_challenge_id = uc.id
+                 JOIN user_status us ON uc.user_id = us.id
+        WHERE crs.month = #{month}
+        ORDER BY crs.rank
+    </select>
+
+    <insert id="insertChallengeRankSnapshot">
+        INSERT INTO challenge_rank_snapshot (user_challenge_id, rank, progress_rate, month)
+        VALUES (#{userChallengeId}, #{rank}, 0, #{month})
+    </insert>
+
+    <resultMap id="participantInfoMap" type="org.scoula.challenge.rank.util.ChallengeParticipantProvider$ParticipantInfo">
+        <result property="userChallengeId" column="user_challenge_id"/>
+        <result property="actualValue" column="actual_value"/>
+    </resultMap>
+
+    <select id="getParticipantsSortedByActualValue" resultMap="participantInfoMap">
+        SELECT
+            uc.ID AS user_challenge_id,
+            uc.actual_value
+        FROM user_challenge uc
+                 INNER JOIN challenge c ON uc.challenge_id = c.ID
+        WHERE c.ID = #{challengeId}
+          AND c.type = 'COMMON'
+        ORDER BY uc.actual_value ASC,
+                 (SELECT COUNT(*) FROM user_challenge sub WHERE sub.user_id = uc.user_id) DESC
+    </select>
+
+    <select id="getParticipantsSortedByActualValueInMonth" resultMap="participantInfoMap">
+        SELECT
+            uc.ID AS user_challenge_id,
+            uc.actual_value
+        FROM user_challenge uc
+                 INNER JOIN challenge c ON uc.challenge_id = c.ID
+        WHERE c.type = 'COMMON'
+          AND DATE_FORMAT(c.start_date, '%Y-%m') = #{month}
+        ORDER BY uc.actual_value ASC,
+                 (SELECT COUNT(*) FROM user_challenge sub WHERE sub.user_id = uc.user_id) DESC
+    </select>
+
+</mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
공통 챌린지 진행률 랭킹, 누적 코인 랭킹 기능 전면 구현 및 관련 테이블 신규 추가 작업입니다.  
랭킹 계산 스케줄러, 조회/저장 API, 테스트용 API까지 전체 흐름을 반영했으며, SqlSessionTemplate 제거 후 Mapper 방식으로 리팩토링했습니다.

## 📖 작업 내용 
- 랭킹 저장용 테이블 4종 추가 (DDL)
  - `challenge_rank`
  - `challenge_rank_snapshot`
  - `challenge_coin_rank`
  - `challenge_coin_rank_snapshot`
- 공통 챌린지 진행률 랭킹 기능
  - 실시간 랭킹 계산 및 저장
  - 월별 스냅샷 저장
  - Top5 + 내 랭킹 조회 API
  - 랭킹 확인 여부 반영 API
- 누적 코인 랭킹 기능
  - 실시간 누적 포인트 기반 랭킹 계산
  - 월별 스냅샷 저장
  - Top5 + 내 랭킹 조회 API
  - 랭킹 확인 여부 반영 API
- 랭킹 계산 스케줄러 2종 구현
- 수동 실행용 테스트 API 추가
- SqlSessionTemplate 제거 및 ChallengeRankMapper 기반으로 리팩토링 완료

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [x] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: #101)

## ✋ 질문 사항
- 추후 랭킹 리셋(초기화) 타이밍 및 월별 보상 로직과의 연동 방식은 어떻게 가져갈지 논의가 필요합니다.

## 🔗 관련 이슈
- closes #101 