### PR TITLE
Feat/#108 quiz point

### DIFF
--- a/src/main/java/org/scoula/quiz/controller/QuizController.java
+++ b/src/main/java/org/scoula/quiz/controller/QuizController.java
@@ -9,6 +9,7 @@ import org.scoula.quiz.domain.QuizHistoryDetailVO;
 import org.scoula.quiz.dto.QuizDTO;
 import org.scoula.quiz.dto.QuizHistoryDTO;
 import org.scoula.quiz.dto.QuizHistoryDetailDTO;
+import org.scoula.quiz.dto.QuizSubmitRequestDTO;
 import org.scoula.quiz.service.QuizService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,8 +35,8 @@ public class QuizController {
 
     @ApiOperation(value = "퀴즈응시기록 저장", notes = "퀴즈응시기록을 저장합니다.")
     @PostMapping("/submit")
-    public ResponseEntity<CommonResponseDTO<QuizDTO>> submit(@ModelAttribute QuizHistoryDTO quizHistoryDTO) {
-        quizService.submit(quizHistoryDTO);
+    public ResponseEntity<CommonResponseDTO<QuizDTO>> submit(@RequestBody QuizSubmitRequestDTO quizSubmitRequestDTO) {
+        quizService.submit(quizSubmitRequestDTO);
         return ResponseEntity.ok(CommonResponseDTO.success("저장성공"));
     }
 

--- a/src/main/java/org/scoula/quiz/dto/QuizSubmitRequestDTO.java
+++ b/src/main/java/org/scoula/quiz/dto/QuizSubmitRequestDTO.java
@@ -1,0 +1,29 @@
+package org.scoula.quiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.scoula.quiz.domain.QuizHistoryVO;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuizSubmitRequestDTO {
+    private Long userId;
+    private Long quizId;
+    private Boolean isCorrect;
+
+
+    public QuizHistoryVO toVO() {
+        QuizHistoryVO quizHistoryVO = new QuizHistoryVO();
+        quizHistoryVO.setQuizId(quizId);
+        quizHistoryVO.setUserId(userId);
+        quizHistoryVO.setIsCorrect(isCorrect);
+        quizHistoryVO.setSubmittedAt(LocalDateTime.now());
+        return quizHistoryVO;
+    }
+}

--- a/src/main/java/org/scoula/quiz/service/QuizService.java
+++ b/src/main/java/org/scoula/quiz/service/QuizService.java
@@ -3,6 +3,7 @@ package org.scoula.quiz.service;
 import org.scoula.quiz.dto.QuizDTO;
 import org.scoula.quiz.dto.QuizHistoryDTO;
 import org.scoula.quiz.dto.QuizHistoryDetailDTO;
+import org.scoula.quiz.dto.QuizSubmitRequestDTO;
 
 import java.util.List;
 
@@ -11,7 +12,7 @@ public interface QuizService {
 
      QuizDTO getQuiz(Long userId);
 
-     void submit(QuizHistoryDTO quizHistoryDTO);
+     void submit(QuizSubmitRequestDTO quizSubmitRequestDTO);
 
      QuizHistoryDetailDTO getHistoryDetail(Long historyId);
 

--- a/src/main/java/org/scoula/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/org/scoula/quiz/service/QuizServiceImpl.java
@@ -1,6 +1,7 @@
 package org.scoula.quiz.service;
 
 import lombok.RequiredArgsConstructor;
+import org.scoula.coin.mapper.CoinMapper;
 import org.scoula.quiz.domain.QuizHistoryDetailVO;
 import org.scoula.quiz.domain.QuizHistoryVO;
 import org.scoula.quiz.domain.QuizVO;
@@ -21,6 +22,7 @@ import java.util.List;
 public class QuizServiceImpl implements QuizService {
 
     final private QuizMapper quizMapper;
+    final private CoinMapper coinMapper;
 
     @Override
     public QuizDTO getQuiz(Long userId) {
@@ -42,10 +44,11 @@ public class QuizServiceImpl implements QuizService {
     }
 
     @Override
-    public void submit(QuizHistoryDTO quizHistoryDTO) {
-        QuizHistoryVO quizHistoryVO = quizHistoryDTO.toVO();
-        //tq
-        quizMapper.insertHistory(quizHistoryVO);
+    public void submit(QuizHistoryDTO dto) {
+        QuizHistoryVO vo = dto.toVO();
+        coinMapper.addCoinAmount(dto.getUserId(),10);
+        coinMapper.insertCoinHistory(dto.getUserId(), 10, "plus", "QUIZ");
+        quizMapper.insertHistory(vo);
     }
 
     @Override

--- a/src/main/java/org/scoula/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/org/scoula/quiz/service/QuizServiceImpl.java
@@ -8,6 +8,7 @@ import org.scoula.quiz.domain.QuizVO;
 import org.scoula.quiz.dto.QuizDTO;
 import org.scoula.quiz.dto.QuizHistoryDTO;
 import org.scoula.quiz.dto.QuizHistoryDetailDTO;
+import org.scoula.quiz.dto.QuizSubmitRequestDTO;
 import org.scoula.quiz.exception.QuizAlreadyTakenTodayException;
 import org.scoula.quiz.exception.QuizNotFoundException;
 import org.scoula.quiz.mapper.QuizMapper;
@@ -44,7 +45,7 @@ public class QuizServiceImpl implements QuizService {
     }
 
     @Override
-    public void submit(QuizHistoryDTO dto) {
+    public void submit(QuizSubmitRequestDTO dto) {
         QuizHistoryVO vo = dto.toVO();
         coinMapper.addCoinAmount(dto.getUserId(),10);
         coinMapper.insertCoinHistory(dto.getUserId(), 10, "plus", "QUIZ");

--- a/src/main/resources/org/scoula/quiz/mapper/QuizMapper.xml
+++ b/src/main/resources/org/scoula/quiz/mapper/QuizMapper.xml
@@ -13,7 +13,7 @@
     </resultMap>
 
 
-    <insert id="insertHistory">
+    <insert id="insertHistory" parameterType="org.scoula.quiz.domain.QuizHistoryVO">
         INSERT INTO `quiz_history` (
             `user_id`,
             `quiz_id`,


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
퀴즈 응답 시 재화를 획득하는 기능을 추가했습니다.
## 📖 작업 내용 
- **인앱 재화 획득 기능 추가**
'오늘의 퀴즈'에 응답을 제출하면 정답 여부와 관계없이 지정된 재화(코인)를 획득합니다.

- **재화 획득 기록 저장**
재화 획득 내역은 coin_history 테이블에 기록되며, 획득 출처가 quiz로 명시됩니다.

- **퀴즈 응시 시, 요청 파라미터 개선**
응시기록에 필요한 파라미터들만 속성으로 갖는 DTO를 만들어, controller의 submit메소드의 파라미터로 대체했습니다.

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
closes #108 