### PR TITLE
refactor: 아바타 기능 재화소비코드 리펙토링

### DIFF
--- a/src/main/java/org/scoula/avatar/controller/AvatarController.java
+++ b/src/main/java/org/scoula/avatar/controller/AvatarController.java
@@ -70,8 +70,8 @@ public class AvatarController {
 
     @ApiOperation(value="유저재화조회", notes="현재 유저가 보유 중인 재화를 조회합니다.")
     @GetMapping("/getCurCoin/userId={userId}")
-    public ResponseEntity<CommonResponseDTO<Long>> getCurCoin(@PathVariable Long userId) {
-        Long curCoin=avatarService.getCoin(userId);
+    public ResponseEntity<CommonResponseDTO<Integer>> getCurCoin(@PathVariable Long userId) {
+        int curCoin=avatarService.getCoin(userId);
         return ResponseEntity.ok(CommonResponseDTO.success("유저재화 조회 성공", curCoin));
     }
 }

--- a/src/main/java/org/scoula/avatar/mapper/AvatarMapper.java
+++ b/src/main/java/org/scoula/avatar/mapper/AvatarMapper.java
@@ -33,13 +33,4 @@ public interface AvatarMapper {
     //clothe테이블의 is_wearing 갱신
     void updateClothe(@Param("userId") Long userId, @Param("isWearing") Boolean isWearing, @Param("items") Long[] items);
 
-    //재화차감
-    void updateMoney(@Param("userId") Long userId,@Param("cost") int cost);
-
-    //재화변동내역 삽입
-    void insertCoinHistory(@Param("userId") Long userId, @Param("amount") int amount, @Param("type") String type, @Param("comment") String comment);
-
-    //유저 재화 조회
-    Long getUserCoin(Long userId);
-
 }

--- a/src/main/java/org/scoula/avatar/service/AvatarService.java
+++ b/src/main/java/org/scoula/avatar/service/AvatarService.java
@@ -17,5 +17,5 @@ public interface AvatarService{
 
     void insertClothe(Long userId, Long itemId);
 
-    Long getCoin(Long userId);
+    int getCoin(Long userId);
 }

--- a/src/main/java/org/scoula/avatar/service/AvatarServiceImpl.java
+++ b/src/main/java/org/scoula/avatar/service/AvatarServiceImpl.java
@@ -9,6 +9,7 @@ import org.scoula.avatar.dto.AvatarDTO;
 import org.scoula.avatar.dto.UserClothesDTO;
 import org.scoula.avatar.exception.InsufficientCoinException;
 import org.scoula.avatar.mapper.AvatarMapper;
+import org.scoula.coin.mapper.CoinMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ import java.util.Map;
 public class AvatarServiceImpl implements AvatarService {
 
     final private AvatarMapper mapper;
+    final private CoinMapper coinMapper;
 
     @Override
     public void insertAvatar(Long userId) {
@@ -93,7 +95,8 @@ public class AvatarServiceImpl implements AvatarService {
     public void insertClothe(Long userId, Long itemId) {
         //유저 재화와 아이템 가격 조회
         ItemsVO itemsVO=mapper.getItem(itemId);
-        Long curAmount=mapper.getUserCoin(userId);
+//        Long curAmount=mapper.getUserCoin(userId);
+        int curAmount=coinMapper.getUserCoin(userId);
         int itemCost=itemsVO.getCost();
 
         //재화가 아이템 가격보다 적으면 예외
@@ -102,14 +105,15 @@ public class AvatarServiceImpl implements AvatarService {
         }
 
         //예외 통과하면 유저재화를 갱신하고 옷장에 의상 삽입
-        mapper.updateMoney(userId,itemCost); //재화 갱신
-        mapper.insertCoinHistory(userId, itemCost, "minus",itemsVO.getName()+" 구매"); //재화소비내역 삽입
         mapper.insertClothe(userId, itemId); //의상소유내역 삽입
+        coinMapper.subtractCoin(userId, itemCost);
+        coinMapper.insertCoinHistory(userId,itemCost,"minus","AVATAR");
+
     }
 
     @Override
-    public Long getCoin(Long userId) {
-        return mapper.getUserCoin(userId);
+    public int getCoin(Long userId) {
+        return coinMapper.getUserCoin(userId);
     }
 }
 

--- a/src/main/resources/org/scoula/avatar/mapper/AvatarMapper.xml
+++ b/src/main/resources/org/scoula/avatar/mapper/AvatarMapper.xml
@@ -65,27 +65,9 @@
     </insert>
 
 
-    <!-- 유저재화차감 -->
-    <update id="updateMoney">
-        UPDATE coin SET amount = amount - #{cost} WHERE id = #{userId}
-    </update>
-
-
-    <!-- 유저재화 조회 -->
-    <select id="getUserCoin" parameterType="Long" resultType="Long">
-        SELECT amount FROM coin WHERE id=#{userId}
-    </select>
-
-
     <!-- 아이템 가격 조회 -->
     <select id="getItem" resultType="org.scoula.avatar.domain.ItemsVO">
         SELECT * FROM item where id=#{itemId}
     </select>
-
-    <!-- 아이템 구매 내역 삽입 -->
-    <insert id="insertCoinHistory">
-        INSERT INTO coin_history (user_id, amount, type, comment)
-        VALUES (#{userId}, #{amount}, #{type}, #{comment})
-    </insert>
 
 </mapper>

--- a/src/main/resources/org/scoula/coin/mapper/CoinMapper.xml
+++ b/src/main/resources/org/scoula/coin/mapper/CoinMapper.xml
@@ -7,9 +7,7 @@
 
     <update id="subtractCoin">
         UPDATE coin
-        SET amount = amount - #{amount},
-            cumulative_amount = cumulative_amount - #{amount},
-            monthly_cumulative_amount = monthly_cumulative_amount - #{amount}
+        SET amount = amount - #{amount}
         WHERE id = #{userId}
     </update>
 


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
아바타 의상 구매 시 재화를 사용하는 로직을 리팩토링했습니다.
## 📖 작업 내용 
- **재화 소비 로직 재사용**
기존에 아바타 기능 내부에 별도로 존재하던 재화 소비 코드를 공용 coin 패키지의 기능을 사용하도록 변경하여 코드의 중복을 제거하고 일관성을 높였습니다.

- **Mapper 기능 수정**
coinMapper의 subtract 메소드가 순수하게 금액을 차감하는 역할만 수행하도록 수정했습니다
## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
closes #126 