### PR TITLE
fix: 로그인 시 응답수정 및 파라미터 수정

### DIFF
--- a/src/main/java/org/scoula/alarm/controller/AlarmController.java
+++ b/src/main/java/org/scoula/alarm/controller/AlarmController.java
@@ -7,7 +7,9 @@ import lombok.extern.log4j.Log4j2;
 import org.scoula.alarm.dto.AlarmDTO;
 import org.scoula.alarm.service.AlarmService;
 import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.security.account.domain.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,9 +24,9 @@ public class AlarmController {
     final private AlarmService alarmService;
 
     @ApiOperation(value="알람 조회", notes="현재 존재하는 알람들을 조회합니다.")
-    @GetMapping("/userId={userId}")
-    public ResponseEntity<CommonResponseDTO<List<AlarmDTO>>> getAlarm(@PathVariable Long userId) {
-        List<AlarmDTO> alarmDTO=alarmService.getAlarms(userId);
+    @GetMapping("")
+    public ResponseEntity<CommonResponseDTO<List<AlarmDTO>>> getAlarm(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<AlarmDTO> alarmDTO=alarmService.getAlarms(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseDTO.success("알람 조회 성공", alarmDTO));
     }
 
@@ -37,8 +39,8 @@ public class AlarmController {
 
     @ApiOperation(value="모든 알람 읽음여부 수정", notes = "유저에게 전달된 모든 알람의 읽음여부를 true로 변경합니다.")
     @PutMapping("/updateAll")
-    public ResponseEntity<CommonResponseDTO<String>> updateAll(@RequestParam Long userId) {
-        alarmService.updateAll(userId);
+    public ResponseEntity<CommonResponseDTO<String>> updateAll(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        alarmService.updateAll(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseDTO.success("전체알람상태 수정 성공"));
     }
 }

--- a/src/main/java/org/scoula/avatar/controller/AvatarController.java
+++ b/src/main/java/org/scoula/avatar/controller/AvatarController.java
@@ -9,7 +9,9 @@ import org.scoula.avatar.dto.AvatarDTO;
 import org.scoula.avatar.dto.UserClothesDTO;
 import org.scoula.avatar.service.AvatarService;
 import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.security.account.domain.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
@@ -27,8 +29,8 @@ public class AvatarController {
     //swagger 테스트용
     @ApiOperation(value="아바타 생성", notes="아바타를 생성합니다.")
     @PostMapping("/userId={userId}")
-    public ResponseEntity<CommonResponseDTO<String>> insertAvatar(@PathVariable Long userId) {
-        avatarService.insertAvatar(userId);
+    public ResponseEntity<CommonResponseDTO<String>> insertAvatar(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        avatarService.insertAvatar(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseDTO.success("아바타 생성 성공"));
     }
 
@@ -36,8 +38,8 @@ public class AvatarController {
     //아바타 착장 조회(get, 파라미터 : Long userId, 반환값 : AvatarDTO)
     @ApiOperation(value="아바타 조회", notes="아바타 상태를 조회합니다.")
     @GetMapping("/userId={userId}")
-    public ResponseEntity<CommonResponseDTO<AvatarDTO>> getAvatar(@PathVariable Long userId) {
-        AvatarDTO avatar = avatarService.getAvatar(userId);
+    public ResponseEntity<CommonResponseDTO<AvatarDTO>> getAvatar(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        AvatarDTO avatar = avatarService.getAvatar(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseDTO.success("아바타 조회성공", avatar));
     }
 
@@ -45,16 +47,16 @@ public class AvatarController {
     //각 아이템들마다 해당하는 타입파악(select type from item where id=#{itemId}) 후, 해당하는 컬럼에 각각 반영
     @ApiOperation(value="아바타 수정", notes = "아바타 상태를 수정합니다.")
     @PutMapping("/updateAvatar")
-    public ResponseEntity<CommonResponseDTO<String>> updateAvatar(@RequestParam Long userId, Long[] items) {
-        avatarService.updateAvatar(userId, items);
+    public ResponseEntity<CommonResponseDTO<String>> updateAvatar( @AuthenticationPrincipal CustomUserDetails userDetails,@RequestParam Long[] items) {
+        avatarService.updateAvatar(userDetails.getUserId(), items);
         return ResponseEntity.ok(CommonResponseDTO.success("아바타 수정성공"));
     }
 
     //의상 전체 조회(get, 파라미터 : Long userId, 반환값 : List<ItemDTO>)
     @ApiOperation(value="의상 전체 조회", notes="의상 전체를 조회합니다. 소유여부도 is_wearing으로 표시합니다.")
     @GetMapping("/getClothes/userId={userId}")
-    public ResponseEntity<CommonResponseDTO<List<UserClothesDTO>>> getClothes(@PathVariable Long userId) {
-        List<UserClothesDTO> userClothes=  avatarService.getUserClothes(userId);
+    public ResponseEntity<CommonResponseDTO<List<UserClothesDTO>>> getClothes(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<UserClothesDTO> userClothes=  avatarService.getUserClothes(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseDTO.success("의상 전체 조회성공", userClothes));
     }
 
@@ -63,15 +65,15 @@ public class AvatarController {
     // -> 가능할 경우 cost만큼 보유재화 차감하고, coin_history에 소비내역 추가, clothes 테이블에 해당 아이템 삽입
     @ApiOperation(value="의상 구매", notes="유저 옷장에 해당 아이템을 넣고 재화를 차감합니다.")
     @PostMapping("/insertClothe")
-    public ResponseEntity<CommonResponseDTO<String>> insertClothe(@RequestParam Long userId, Long itemId){
-        avatarService.insertClothe(userId, itemId);
+    public ResponseEntity<CommonResponseDTO<String>> insertClothe(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam Long itemId){
+        avatarService.insertClothe(userDetails.getUserId(), itemId);
         return ResponseEntity.ok(CommonResponseDTO.success("의상 구매성공"));
     }
 
     @ApiOperation(value="유저재화조회", notes="현재 유저가 보유 중인 재화를 조회합니다.")
     @GetMapping("/getCurCoin/userId={userId}")
-    public ResponseEntity<CommonResponseDTO<Integer>> getCurCoin(@PathVariable Long userId) {
-        int curCoin=avatarService.getCoin(userId);
+    public ResponseEntity<CommonResponseDTO<Integer>> getCurCoin(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        int curCoin=avatarService.getCoin(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseDTO.success("유저재화 조회 성공", curCoin));
     }
 }

--- a/src/main/java/org/scoula/quiz/controller/QuizController.java
+++ b/src/main/java/org/scoula/quiz/controller/QuizController.java
@@ -11,7 +11,10 @@ import org.scoula.quiz.dto.QuizHistoryDTO;
 import org.scoula.quiz.dto.QuizHistoryDetailDTO;
 import org.scoula.quiz.dto.QuizSubmitRequestDTO;
 import org.scoula.quiz.service.QuizService;
+import org.scoula.security.account.domain.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,29 +31,29 @@ public class QuizController {
 
     @ApiOperation(value = "오늘의퀴즈 조회", notes = "오늘의 퀴즈를 랜덤으로 제공합니다. 유저가 이전에 풀었던 문제는 필터링합니다.")
     @GetMapping("/todaysQuiz")
-    public ResponseEntity<CommonResponseDTO<QuizDTO>> getQuiz(@RequestParam Long userId) {
-        QuizDTO todaysQuiz = quizService.getQuiz(userId);
+    public ResponseEntity<CommonResponseDTO<QuizDTO>> getQuiz(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        QuizDTO todaysQuiz = quizService.getQuiz(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseDTO.success("퀴즈 조회 성공", todaysQuiz));
     }
 
     @ApiOperation(value = "퀴즈응시기록 저장", notes = "퀴즈응시기록을 저장합니다.")
     @PostMapping("/submit")
-    public ResponseEntity<CommonResponseDTO<QuizDTO>> submit(@RequestBody QuizSubmitRequestDTO quizSubmitRequestDTO) {
-        quizService.submit(quizSubmitRequestDTO);
+    public ResponseEntity<CommonResponseDTO<QuizDTO>> submit(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody QuizSubmitRequestDTO quizSubmitRequestDTO) {
+        quizService.submit(userDetails.getUserId(),quizSubmitRequestDTO);
         return ResponseEntity.ok(CommonResponseDTO.success("저장성공"));
     }
 
     @ApiOperation(value = "퀴즈히스토리 내역조회", notes = "유저의 퀴즈응시기록들을 조회합니다.")
     @GetMapping("/HistoryList")
-    public ResponseEntity<CommonResponseDTO<List<QuizHistoryDetailDTO>>> HistoryList(@RequestParam Long userId) {
-        List<QuizHistoryDetailDTO> historyList = quizService.getHistoryList(userId);
+    public ResponseEntity<CommonResponseDTO<List<QuizHistoryDetailDTO>>> HistoryList(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<QuizHistoryDetailDTO> historyList = quizService.getHistoryList(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseDTO.success("퀴즈히스토리 내역조회 성공",historyList));
     }
 
     @ApiOperation(value = "퀴즈히스토리 상세조회", notes = "유저의 퀴즈응시기록들을 상세조회합니다.")
     @GetMapping("/HistoryDetail")
-    public ResponseEntity<CommonResponseDTO<QuizHistoryDetailDTO>> HistoryDetail(@RequestParam Long historyId) {
-        QuizHistoryDetailDTO QuizhistoryDetail = quizService.getHistoryDetail(historyId);
+    public ResponseEntity<CommonResponseDTO<QuizHistoryDetailDTO>> HistoryDetail(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        QuizHistoryDetailDTO QuizhistoryDetail = quizService.getHistoryDetail(userDetails.getUserId());
         return ResponseEntity.ok(CommonResponseDTO.success("퀴즈히스토리 상세조회성공",QuizhistoryDetail));
     }
 }

--- a/src/main/java/org/scoula/quiz/dto/QuizSubmitRequestDTO.java
+++ b/src/main/java/org/scoula/quiz/dto/QuizSubmitRequestDTO.java
@@ -13,15 +13,15 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class QuizSubmitRequestDTO {
-    private Long userId;
+
     private Long quizId;
     private Boolean isCorrect;
 
-
     public QuizHistoryVO toVO() {
         QuizHistoryVO quizHistoryVO = new QuizHistoryVO();
+        quizHistoryVO.setQuizId(null);
+        quizHistoryVO.setUserId(null);
         quizHistoryVO.setQuizId(quizId);
-        quizHistoryVO.setUserId(userId);
         quizHistoryVO.setIsCorrect(isCorrect);
         quizHistoryVO.setSubmittedAt(LocalDateTime.now());
         return quizHistoryVO;

--- a/src/main/java/org/scoula/quiz/service/QuizService.java
+++ b/src/main/java/org/scoula/quiz/service/QuizService.java
@@ -12,7 +12,7 @@ public interface QuizService {
 
      QuizDTO getQuiz(Long userId);
 
-     void submit(QuizSubmitRequestDTO quizSubmitRequestDTO);
+     void submit(Long userId, QuizSubmitRequestDTO quizSubmitRequestDTO);
 
      QuizHistoryDetailDTO getHistoryDetail(Long historyId);
 

--- a/src/main/java/org/scoula/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/org/scoula/quiz/service/QuizServiceImpl.java
@@ -45,11 +45,17 @@ public class QuizServiceImpl implements QuizService {
     }
 
     @Override
-    public void submit(QuizSubmitRequestDTO dto) {
-        QuizHistoryVO vo = dto.toVO();
-        coinMapper.addCoinAmount(dto.getUserId(),10);
-        coinMapper.insertCoinHistory(dto.getUserId(), 10, "plus", "QUIZ");
-        quizMapper.insertHistory(vo);
+    public void submit(Long userId, QuizSubmitRequestDTO dto) {
+
+        QuizHistoryDTO quizHistoryDTO=QuizHistoryDTO.builder()
+                .userId(userId)
+                .quizId(dto.getQuizId())
+                .isCorrect(dto.getIsCorrect())
+                .build();
+
+        coinMapper.addCoinAmount(userId,10);
+        coinMapper.insertCoinHistory(userId, 10, "plus", "QUIZ");
+        quizMapper.insertHistory(quizHistoryDTO.toVO());
     }
 
     @Override

--- a/src/main/java/org/scoula/security/account/domain/CustomUserDetails.java
+++ b/src/main/java/org/scoula/security/account/domain/CustomUserDetails.java
@@ -61,4 +61,5 @@ public class CustomUserDetails implements UserDetails {
     public String getUserName() {
         return user.getUserName();
     }
+
 }

--- a/src/main/java/org/scoula/security/account/dto/AuthResultDTO.java
+++ b/src/main/java/org/scoula/security/account/dto/AuthResultDTO.java
@@ -11,4 +11,5 @@ public class AuthResultDTO {
     private String accessToken;
     private String refreshToken;
     private UserInfoDTO user;
+    private String NickName;
 }

--- a/src/main/java/org/scoula/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/org/scoula/security/handler/LoginSuccessHandler.java
@@ -9,6 +9,7 @@ import org.scoula.security.account.dto.AuthResultDTO;
 import org.scoula.security.account.dto.UserInfoDTO;
 import org.scoula.security.account.domain.CustomUserDetails;
 import org.scoula.security.util.JsonResponse;
+import org.scoula.user.mapper.UserStatusMapper;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -24,6 +25,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtUtil jwtUtil;
     private final RedisService redisService;
+    private final UserStatusMapper userStatusMapper;
 
     @Override
     public void onAuthenticationSuccess(
@@ -50,9 +52,10 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         // 유저 정보 DTO 변환
         UserInfoDTO userInfo = UserInfoDTO.from(userDetails.getUser());
+        String nickname=userStatusMapper.getNickname(id);
 
         // 응답용 DTO 생성
-        AuthResultDTO authResult = new AuthResultDTO(accessToken, refreshToken, userInfo);
+        AuthResultDTO authResult = new AuthResultDTO(accessToken, refreshToken, userInfo,nickname);
         CommonResponseDTO<AuthResultDTO> responseDTO = CommonResponseDTO.success("로그인 성공", authResult);
 
         // JSON 응답 전송

--- a/src/main/java/org/scoula/security/service/CustomUserDetailsService.java
+++ b/src/main/java/org/scoula/security/service/CustomUserDetailsService.java
@@ -5,6 +5,7 @@ import lombok.extern.log4j.Log4j2;
 import org.scoula.security.account.domain.CustomUserDetails;
 import org.scoula.security.account.mapper.UserDetailsMapper;
 import org.scoula.user.domain.User;
+import org.scoula.user.mapper.UserStatusMapper;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;

--- a/src/main/java/org/scoula/user/mapper/UserStatusMapper.java
+++ b/src/main/java/org/scoula/user/mapper/UserStatusMapper.java
@@ -7,4 +7,5 @@ import org.scoula.user.domain.UserStatus;
 public interface UserStatusMapper {
     void save(UserStatus status);
     boolean isNicknameDuplicated(String nickname);
+    String getNickname(Long userId);
 }

--- a/src/main/resources/org/scoula/user/mapper/UserStatusMapper.xml
+++ b/src/main/resources/org/scoula/user/mapper/UserStatusMapper.xml
@@ -14,4 +14,8 @@
         SELECT EXISTS(SELECT 1 FROM user_status WHERE nickname = #{nickname})
     </select>
 
+    <select id="getNickname" resultType="java.lang.String">
+        SELECT nickname from user_status where id=#{userId}
+    </select>
+
 </mapper>


### PR DESCRIPTION


closes #130

# 📌 Pull Request

## 👀 작업 요약 
컨트롤로 파라미터와 로그인 반환값 수정
## 📖 작업 내용 
컨트롤러에서 이전에 수정하지 못한 Long id 파라미터들을 발견
security context의 principal 참조하도록 교체
로그인 성공 핸들러에 닉네임도 반환하도록 수정
## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
closes #130 