### PR TITLE
 JWT 기반 유저 식별 적용 및 userId 임시값 제거

### DIFF
--- a/src/main/java/org/scoula/account/controller/AccountController.java
+++ b/src/main/java/org/scoula/account/controller/AccountController.java
@@ -1,16 +1,15 @@
 package org.scoula.account.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.scoula.account.dto.AccountDto;
 import org.scoula.account.dto.AccountListWithTotalDto;
 import org.scoula.account.dto.AccountRegisterResponseDto;
 import org.scoula.account.service.AccountService;
 import org.scoula.common.dto.CommonResponseDTO;
 import org.scoula.nhapi.dto.FinAccountRequestDto;
+import org.scoula.security.account.domain.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/accounts")
@@ -21,43 +20,55 @@ public class AccountController {
 
     // 계좌 등록 및 핀어카운트 발급
     @PostMapping("/register")
-    public ResponseEntity<CommonResponseDTO<String>> registerAccount(@RequestBody FinAccountRequestDto dto) {
-        // AccountRegisterResponseDto 반환
-        AccountRegisterResponseDto responseDto = accountService.registerFinAccount(dto);
+    public ResponseEntity<CommonResponseDTO<String>> registerAccount(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody FinAccountRequestDto dto) {
 
-        // 핀어카운트 정보를 응답으로 반환
+        Long userId = user.getUserId();
+        AccountRegisterResponseDto responseDto = accountService.registerFinAccount(userId, dto);
         String finAcno = responseDto.getFinAccount();
         return ResponseEntity.ok(CommonResponseDTO.success("계좌 등록 성공 및 핀어카운트 발급 성공", finAcno));
     }
 
     // 잔액 및 거래내역 동기화
     @PostMapping("/{accountId}/sync")
-    public ResponseEntity<CommonResponseDTO<Void>> syncAccountData(@PathVariable Long accountId) {
-        accountService.syncAccountById(accountId);
+    public ResponseEntity<CommonResponseDTO<Void>> syncAccountData(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long accountId) {
+
+        Long userId = user.getUserId();
+        accountService.syncAccountById(userId, accountId);
         return ResponseEntity.ok(CommonResponseDTO.success("계좌 동기화 성공", null));
     }
 
-    // 전체 계좌 동기화 (userId 기준)
-    @PostMapping("/sync-all/{userId}")
-    public ResponseEntity<CommonResponseDTO<Void>> syncAllAccounts(@PathVariable Long userId) {
+    // 전체 계좌 동기화
+    @PostMapping("/sync-all")
+    public ResponseEntity<CommonResponseDTO<Void>> syncAllAccounts(
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        Long userId = user.getUserId();
         accountService.syncAllAccountsByUserId(userId);
         return ResponseEntity.ok(CommonResponseDTO.success("사용자 전체 계좌 동기화 성공", null));
     }
 
+    // 계좌 삭제 (비활성화)
     @DeleteMapping("/{accountId}")
     public ResponseEntity<CommonResponseDTO<Void>> deleteAccount(
-            @PathVariable Long accountId,
-            @RequestParam Long userId //TODO 나중에 @AuthenticationPrincipal로 바꾸기
-    ) {
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long accountId) {
+
+        Long userId = user.getUserId();
         accountService.deactivateAccount(accountId, userId);
         return ResponseEntity.ok(CommonResponseDTO.success("계좌 비활성화 완료"));
     }
 
-    @GetMapping("/users/{userId}/list")
-    public ResponseEntity<CommonResponseDTO<AccountListWithTotalDto>> getAccountsWithTotal(@PathVariable Long userId) {
+    // 계좌 목록 조회
+    @GetMapping("/list")
+    public ResponseEntity<CommonResponseDTO<AccountListWithTotalDto>> getAccountsWithTotal(
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        Long userId = user.getUserId();
         AccountListWithTotalDto result = accountService.getAccountsWithTotal(userId);
         return ResponseEntity.ok(CommonResponseDTO.success("계좌 목록 조회 성공", result));
     }
-
-
 }

--- a/src/main/java/org/scoula/account/dto/AccountDto.java
+++ b/src/main/java/org/scoula/account/dto/AccountDto.java
@@ -23,10 +23,17 @@ public class AccountDto {
     public static AccountDto from(Account account) {
         return AccountDto.builder()
                 .id(account.getId())
-                .accountNumber(account.getAccountNumber())
+                .accountNumber(maskAccountNumber(account.getAccountNumber()))
                 .productName(account.getProductName())
                 .accountType(account.getAccountType())
                 .balance(account.getBalance())
                 .build();
+    }
+
+    private static String maskAccountNumber(String accountNumber) {
+        if (accountNumber == null || accountNumber.length() < 8) return "****";
+        String prefix = accountNumber.substring(0, 4);
+        String suffix = accountNumber.substring(accountNumber.length() - 4);
+        return prefix + "-****-" + suffix;
     }
 }

--- a/src/main/java/org/scoula/account/service/AccountService.java
+++ b/src/main/java/org/scoula/account/service/AccountService.java
@@ -8,8 +8,8 @@ import org.scoula.account.dto.AccountRegisterResponseDto;
 import java.util.List;
 
 public interface AccountService {
-    AccountRegisterResponseDto registerFinAccount(FinAccountRequestDto dto);
-    void syncAccountById(Long accountId);
+    AccountRegisterResponseDto registerFinAccount(Long userId, FinAccountRequestDto dto);
+    void syncAccountById(Long userId, Long accountId);
     void syncAllAccountsByUserId(Long userId);
     void deactivateAccount(Long accountId, Long userId);;
     AccountListWithTotalDto getAccountsWithTotal(Long userId);

--- a/src/main/java/org/scoula/card/controller/CardController.java
+++ b/src/main/java/org/scoula/card/controller/CardController.java
@@ -1,14 +1,15 @@
 package org.scoula.card.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.scoula.account.dto.AccountDto;
 import org.scoula.card.dto.CardDto;
 import org.scoula.card.dto.CardRegisterResponseDto;
 import org.scoula.card.service.CardService;
 import org.scoula.common.dto.CommonResponseDTO;
 import org.scoula.nhapi.dto.FinCardRequestDto;
+import org.scoula.security.account.domain.CustomUserDetails;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.YearMonth;
@@ -22,38 +23,47 @@ public class CardController {
     private final CardService cardService;
 
     @PostMapping("/register")
-    public ResponseEntity<CommonResponseDTO<CardRegisterResponseDto>> registerCard(@RequestBody FinCardRequestDto dto) {
-        CardRegisterResponseDto response = cardService.registerCard(dto);
+    public ResponseEntity<CommonResponseDTO<CardRegisterResponseDto>> registerCard(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody FinCardRequestDto dto) {
+        Long userId = user.getUserId();
+        CardRegisterResponseDto response = cardService.registerCard(userId, dto);
         return ResponseEntity.ok(CommonResponseDTO.success("카드 등록 및 승인내역 저장 완료", response));
     }
 
     @PostMapping("/{cardId}/sync")
-    public ResponseEntity<CommonResponseDTO<Void>> syncCardData(@PathVariable Long cardId) {
-        cardService.syncCardById(cardId);
+    public ResponseEntity<CommonResponseDTO<Void>> syncCardData(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long cardId) {
+        Long userId = user.getUserId();
+        cardService.syncCardById(userId, cardId);
         return ResponseEntity.ok(CommonResponseDTO.success("카드 승인내역 동기화 완료"));
     }
 
-    @PostMapping("/sync-all/{userId}")
-    public ResponseEntity<CommonResponseDTO<Void>> syncAllCards(@PathVariable Long userId) {
+    @PostMapping("/sync-all")
+    public ResponseEntity<CommonResponseDTO<Void>> syncAllCards(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        Long userId = user.getUserId();
         cardService.syncAllCardsByUserId(userId);
         return ResponseEntity.ok(CommonResponseDTO.success("사용자의 모든 카드 승인내역 동기화 완료"));
     }
 
     @DeleteMapping("/{cardId}")
     public ResponseEntity<CommonResponseDTO<Void>> deleteCard(
-            @PathVariable Long cardId,
-            @RequestParam Long userId //TODO 나중에 @AuthenticationPrincipal로 바꾸기
-    ) {
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long cardId) {
+        Long userId = user.getUserId();
         cardService.deactivateCard(cardId, userId);
         return ResponseEntity.ok(CommonResponseDTO.success("카드 비활성화 완료"));
     }
 
-    @GetMapping("/users/{userId}/list")
-    public ResponseEntity<CommonResponseDTO<List<CardDto>>> getCardsWithTotal(@PathVariable Long userId,
-                                                                              @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth month) {
+    @GetMapping("/list")
+    public ResponseEntity<CommonResponseDTO<List<CardDto>>> getCardsWithTotal(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth month) {
+        Long userId = user.getUserId();
         YearMonth targetMonth = month != null ? month : YearMonth.now();
         List<CardDto> result = cardService.getCardsWithMonth(userId, targetMonth);
         return ResponseEntity.ok(CommonResponseDTO.success("카드 목록 조회 성공", result));
     }
-
 }

--- a/src/main/java/org/scoula/card/service/CardService.java
+++ b/src/main/java/org/scoula/card/service/CardService.java
@@ -8,8 +8,8 @@ import java.time.YearMonth;
 import java.util.List;
 
 public interface CardService {
-    CardRegisterResponseDto registerCard(FinCardRequestDto dto);
-    void syncCardById(Long cardId);
+    CardRegisterResponseDto registerCard(Long userId, FinCardRequestDto dto);
+    void syncCardById(Long userId, Long cardId);
     void syncAllCardsByUserId(Long userId);
     void deactivateCard(Long cardId, Long userId);
     List<CardDto> getCardsWithMonth(Long userId, YearMonth month);

--- a/src/main/java/org/scoula/monthreport/controller/MonthReportController.java
+++ b/src/main/java/org/scoula/monthreport/controller/MonthReportController.java
@@ -2,9 +2,7 @@ package org.scoula.monthreport.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.scoula.common.dto.CommonResponseDTO;
 import org.scoula.common.exception.BaseException;
 import org.scoula.monthreport.dto.MonthReportDetailDto;
@@ -12,6 +10,8 @@ import org.scoula.monthreport.service.MonthReportGenerator;
 import org.scoula.monthreport.service.MonthReportInitService;
 import org.scoula.monthreport.service.MonthReportReadService;
 import org.scoula.monthreport.util.MonthReportPdfGenerator;
+import org.scoula.security.account.domain.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -30,49 +30,50 @@ public class MonthReportController {
     private final MonthReportPdfGenerator pdfGenerator;
 
     @ApiOperation(value = "월간 리포트 상세 조회", notes = "해당 월의 전체 리포트 데이터를 조회합니다.")
-    @GetMapping("/{userId}/{month}")
+    @GetMapping("/{month}")
     public CommonResponseDTO<MonthReportDetailDto> getReport(
-            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable String month // ex: "2025-07"
     ) {
+        Long userId = user.getUserId();
         MonthReportDetailDto dto = monthReportReadService.getReport(userId, month);
         return CommonResponseDTO.success("월간 리포트 조회 성공", dto);
     }
 
     @ApiOperation(value = "월간 리포트 초기 생성", notes = "ledger 기반으로 이번 달 이전의 리포트를 생성합니다.")
     @PostMapping("/init")
-    public CommonResponseDTO<List<String>> initReports(@RequestBody InitRequest request) {
-        List<String> result = monthReportInitService.generateAllMissingReports(request.getUserId());
+    public CommonResponseDTO<List<String>> initReports(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        List<String> result = monthReportInitService.generateAllMissingReports(userId);
         return CommonResponseDTO.success("총 " + result.size() + "개의 리포트가 생성되었습니다.", result);
     }
 
-    @ApiOperation(value = "월간 리포트 수동 생성", notes = "테스트 용도. userId, month를 받아 해당 월 리포트를 수동 생성합니다.")
+    @ApiOperation(value = "월간 리포트 수동 생성", notes = "테스트 용도. month를 받아 해당 월 리포트를 수동 생성합니다.")
     @PostMapping
     public CommonResponseDTO<String> generateManual(
-            @RequestParam Long userId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam String month
     ) {
+        Long userId = user.getUserId();
         monthReportGenerator.generate(userId, month);
         return CommonResponseDTO.success("리포트 수동 생성 완료");
     }
 
-    @Getter
-    @Setter
-    public static class InitRequest {
-        private Long userId;
-    }
-
     @ApiOperation(value = "월간 리포트 PDF 다운로드", notes = "선택한 월의 리포트를 PDF로 저장합니다.")
-    @GetMapping("/export/{userId}")
-    public void exportReport(@PathVariable Long userId,
-                             @RequestParam String month,
-                             @RequestParam String format,
-                             HttpServletResponse response) throws IOException {
+    @GetMapping("/export")
+    public void exportReport(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestParam String month,
+            @RequestParam String format,
+            HttpServletResponse response
+    ) throws IOException {
 
         if (!"pdf".equalsIgnoreCase(format)) {
             throw new BaseException("지원하지 않는 포맷입니다", 400);
         }
-
+        Long userId = user.getUserId();
         MonthReportDetailDto dto = monthReportReadService.getReport(userId, month);
         String html = pdfGenerator.buildHtmlFromDto(dto);
         byte[] pdfBytes = pdfGenerator.generateHtmlPdf(html);
@@ -81,6 +82,4 @@ public class MonthReportController {
         response.setHeader("Content-Disposition", "attachment; filename=monthreport_" + month + ".pdf");
         response.getOutputStream().write(pdfBytes);
     }
-
-
 }

--- a/src/main/java/org/scoula/transactions/controller/AccountTransactionController.java
+++ b/src/main/java/org/scoula/transactions/controller/AccountTransactionController.java
@@ -5,13 +5,15 @@ import lombok.RequiredArgsConstructor;
 import org.scoula.transactions.dto.AccountTransactionDto;
 import org.scoula.transactions.service.AccountTransactionService;
 import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.security.account.domain.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @Api(tags = "transaction-controller")
 @RestController
-@RequestMapping("/api/users/{userId}/accounts/{accountId}/transactions")
+@RequestMapping("/api/accounts/{accountId}/transactions")
 @RequiredArgsConstructor
 public class AccountTransactionController {
 
@@ -19,13 +21,13 @@ public class AccountTransactionController {
 
     @GetMapping
     public CommonResponseDTO<List<AccountTransactionDto>> getAccountTransactions(
-            @PathVariable Long userId,
-            @RequestParam Long accountId,
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long accountId,
             @RequestParam(required = false) String from,
             @RequestParam(required = false) String to) {
 
+        Long userId = user.getUserId();
         List<AccountTransactionDto> result = accountTransactionService.getTransactions(userId, accountId, from, to);
         return CommonResponseDTO.success("계좌 거래내역 조회 성공", result);
     }
-
 }

--- a/src/main/java/org/scoula/transactions/controller/CardTransactionController.java
+++ b/src/main/java/org/scoula/transactions/controller/CardTransactionController.java
@@ -5,13 +5,15 @@ import lombok.RequiredArgsConstructor;
 import org.scoula.transactions.dto.CardTransactionDto;
 import org.scoula.transactions.service.CardTransactionService;
 import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.security.account.domain.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @Api(tags = "transaction-controller")
 @RestController
-@RequestMapping("/api/users/{userId}/cards/{cardId}/transactions")
+@RequestMapping("/api/cards/{cardId}/transactions")
 @RequiredArgsConstructor
 public class CardTransactionController {
 
@@ -19,14 +21,13 @@ public class CardTransactionController {
 
     @GetMapping
     public CommonResponseDTO<List<CardTransactionDto>> getCardTransactions(
-            @PathVariable Long userId,
-            @RequestParam Long cardId,
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long cardId,
             @RequestParam(required = false) String from,
             @RequestParam(required = false) String to) {
 
+        Long userId = user.getUserId();
         List<CardTransactionDto> result = cardTransactionService.getCardTransactions(userId, cardId, from, to);
         return CommonResponseDTO.success("카드 승인내역 조회 성공", result);
     }
-
-
 }

--- a/src/main/java/org/scoula/transactions/controller/LedgerController.java
+++ b/src/main/java/org/scoula/transactions/controller/LedgerController.java
@@ -10,13 +10,15 @@ import org.scoula.transactions.dto.LedgerMemoUpdateDto;
 import org.scoula.transactions.service.LedgerEditService;
 import org.scoula.transactions.service.LedgerService;
 import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.security.account.domain.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @Api(tags = "transaction-controller")
 @RestController
-@RequestMapping("/api/users/{userId}/ledger")
+@RequestMapping("/api/ledger")
 @RequiredArgsConstructor
 public class LedgerController {
 
@@ -26,11 +28,12 @@ public class LedgerController {
     @ApiOperation("통합 거래내역 조회 (카테고리, 기간 필터 지원)")
     @GetMapping
     public CommonResponseDTO<List<LedgerDto>> getLedgerList(
-            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(required = false) String from,
             @RequestParam(required = false) String to,
             @RequestParam(required = false) String category) {
 
+        Long userId = user.getUserId();
         List<LedgerDto> result = ledgerService.getLedgers(userId, from, to, category);
         return CommonResponseDTO.success("거래내역 조회 성공", result);
     }
@@ -38,8 +41,9 @@ public class LedgerController {
     @ApiOperation("거래 상세 내역 조회")
     @GetMapping("/{ledgerId}")
     public CommonResponseDTO<LedgerDetailDto> getLedgerDetail(
-            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long ledgerId) {
+        Long userId = user.getUserId();
         LedgerDetailDto result = ledgerService.getLedgerDetail(userId, ledgerId);
         return CommonResponseDTO.success("거래 상세 조회 성공", result);
     }
@@ -47,9 +51,11 @@ public class LedgerController {
     @ApiOperation("거래 카테고리 수정")
     @PatchMapping("/{ledgerId}/category")
     public CommonResponseDTO<Void> updateLedgerCategory(
-            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long ledgerId,
             @RequestBody LedgerCategoryUpdateDto dto) {
+        Long userId = user.getUserId();
+        // 권한 검증이 필요한 경우 userId 넘겨서 서비스에서 처리
         ledgerEditService.updateCategory(ledgerId, dto.getCategoryId());
         return CommonResponseDTO.success("카테고리 수정 완료", null);
     }
@@ -57,11 +63,12 @@ public class LedgerController {
     @ApiOperation("거래 메모 수정")
     @PatchMapping("/{ledgerId}/memo")
     public CommonResponseDTO<Void> updateLedgerMemo(
-            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long ledgerId,
             @RequestBody LedgerMemoUpdateDto dto) {
+        Long userId = user.getUserId();
+        // 권한 검증이 필요한 경우 userId 넘겨서 서비스에서 처리
         ledgerEditService.updateMemo(ledgerId, dto.getMemo());
         return CommonResponseDTO.success("메모 수정 완료", null);
     }
-
 }

--- a/src/main/java/org/scoula/transactions/domain/CardTransaction.java
+++ b/src/main/java/org/scoula/transactions/domain/CardTransaction.java
@@ -1,6 +1,7 @@
 package org.scoula.transactions.domain;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.scoula.nhapi.dto.NhCardTransactionResponseDto;
 
@@ -10,6 +11,7 @@ import java.time.format.DateTimeFormatter;
 
 @Slf4j
 @Data
+@NoArgsConstructor
 public class CardTransaction {
     private Long id;
     private Long userId;


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약
- 컨트롤러 전반에 걸쳐 userId 하드코딩 및 임시값 제거
- JWT 인증 기반 Spring Security 표준(@AuthenticationPrincipal) 방식으로 유저 정보 주입 통일

## 📖 작업 내용
- 기존 Authorization 헤더에서 직접 토큰 파싱 및 userId 추출 → **@AuthenticationPrincipal CustomUserDetails user** 방식으로 일원화
- 서비스 및 도메인 로직에서 하드코딩된 userId(예: 1L 등) 제거, 실제 로그인 유저 정보 사용하도록 리팩토링
- 각종 API(userId path/requestParam 등)에서 userId 파라미터 제거, 인증 객체에서 주입
- 코드 내 임시 유저 식별자, 테스트 계정 등 관련 부분 전부 삭제
- JWT 기반 인증/인가 로직을 전담 필터에서 일원 처리하도록 개선

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#139`)

## ✋ 질문 사항
- 없음

## 🔗 관련 이슈

- closes #139
