### PR TITLE
refactor: JWT 전달 방식 개선 및 주식 추천 로직 수정

### DIFF
--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -7,10 +7,12 @@ import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
 import org.scoula.challenge.service.ChallengeService;
 import org.scoula.common.dto.CommonResponseDTO;
-import org.scoula.security.util.JwtUtil;
+import org.scoula.security.account.domain.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
@@ -22,16 +24,14 @@ import java.util.List;
 public class ChallengeController {
 
     private final ChallengeService challengeService;
-    private final JwtUtil jwtUtil;
 
+    // ✅ 토큰 직접 파싱 제거, @AuthenticationPrincipal 로 유저 주입
     @PostMapping("/create")
     public CommonResponseDTO<ChallengeCreateResponseDTO> createChallenge(
             @RequestBody ChallengeCreateRequestDTO req,
-            HttpServletRequest request) {
+            @AuthenticationPrincipal CustomUserDetails user) {
 
-        String bearer = request.getHeader("Authorization");
-        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
-
+        Long userId = user.getUserId();
         ChallengeCreateResponseDTO result = challengeService.createChallenge(userId, req);
         return CommonResponseDTO.success("챌린지가 생성되었습니다.", result);
     }
@@ -41,32 +41,30 @@ public class ChallengeController {
             @RequestParam(value = "type", required = false) ChallengeType type,
             @RequestParam(value = "status", required = false) ChallengeStatus status,
             @RequestParam(value = "participating", required = false) Boolean participating,
-            HttpServletRequest request) {
+            @AuthenticationPrincipal CustomUserDetails user) {
 
-        String bearer = request.getHeader("Authorization");
-        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
-
+        Long userId = user.getUserId();
         List<ChallengeListResponseDTO> challenges = challengeService.getChallenges(userId, type, status, participating);
         return CommonResponseDTO.success("챌린지 리스트 조회 성공", challenges);
     }
 
     @GetMapping("/{id}")
-    public CommonResponseDTO<ChallengeDetailResponseDTO> getChallengeDetail(@PathVariable("id") Long id,
-                                                                            HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+    public CommonResponseDTO<ChallengeDetailResponseDTO> getChallengeDetail(
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        Long userId = user.getUserId();
         ChallengeDetailResponseDTO detail = challengeService.getChallengeDetail(userId, id);
         return CommonResponseDTO.success("챌린지 상세 조회 성공", detail);
     }
 
     @PostMapping("/{id}/join")
-    public CommonResponseDTO<?> joinChallenge(@PathVariable("id") Long challengeId,
-                                              @RequestBody(required = false) ChallengeJoinRequestDTO joinRequest,
-                                              HttpServletRequest request) {
+    public CommonResponseDTO<?> joinChallenge(
+            @PathVariable("id") Long challengeId,
+            @RequestBody(required = false) ChallengeJoinRequestDTO joinRequest,
+            @AuthenticationPrincipal CustomUserDetails user) {
 
-        String bearer = request.getHeader("Authorization");
-        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
-
+        Long userId = user.getUserId();
         Integer password = (joinRequest != null) ? joinRequest.getPassword() : null;
 
         challengeService.joinChallenge(userId, challengeId, password);
@@ -74,41 +72,40 @@ public class ChallengeController {
     }
 
     @GetMapping("/summary")
-    public CommonResponseDTO<ChallengeSummaryResponseDTO> getChallengeSummary(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+    public CommonResponseDTO<ChallengeSummaryResponseDTO> getChallengeSummary(
+            @AuthenticationPrincipal CustomUserDetails user) {
 
+        Long userId = user.getUserId();
         ChallengeSummaryResponseDTO summary = challengeService.getChallengeSummary(userId);
         return CommonResponseDTO.success("챌린지 요약 정보 조회 성공", summary);
     }
 
     @GetMapping("/{id}/result")
-    public CommonResponseDTO<ChallengeResultResponseDTO> getChallengeResult(@PathVariable("id") Long challengeId,
-                                                                            HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        String accessToken = bearer.replace("Bearer ", "");
-        Long userId = jwtUtil.getIdFromToken(accessToken);
-
-        ChallengeResultResponseDTO result = challengeService.getChallengeResult(userId, challengeId, accessToken);
+    public CommonResponseDTO<ChallengeResultResponseDTO> getChallengeResult(
+            @PathVariable("id") Long challengeId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        ChallengeResultResponseDTO result = challengeService.getChallengeResult(userId, challengeId);
         return CommonResponseDTO.success("챌린지 결과 조회 성공", result);
     }
 
-
     @PatchMapping("/{id}/result/confirm")
-    public CommonResponseDTO<?> confirmChallengeResult(@PathVariable("id") Long challengeId,
-                                                       HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+    public CommonResponseDTO<?> confirmChallengeResult(
+            @PathVariable("id") Long challengeId,
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        Long userId = user.getUserId();
         challengeService.confirmChallengeResult(userId, challengeId);
         return CommonResponseDTO.success("챌린지 결과 확인 처리 완료");
     }
 
     @GetMapping("/has-unconfirmed")
-    public CommonResponseDTO<Boolean> hasUnconfirmedChallengeResult(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        Long userId = jwtUtil.getIdFromToken(bearer.replace("Bearer ", ""));
+    public CommonResponseDTO<Boolean> hasUnconfirmedChallengeResult(
+            @AuthenticationPrincipal CustomUserDetails user) {
+
+        Long userId = user.getUserId();
         boolean result = challengeService.hasUnconfirmedResult(userId);
         return CommonResponseDTO.success("미확인 결과 존재 여부 확인", result);
     }
-
 }

--- a/src/main/java/org/scoula/challenge/service/ChallengeService.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeService.java
@@ -13,7 +13,7 @@ public interface ChallengeService {
     void joinChallenge(Long userId, Long challengeId, Integer password);
     ChallengeSummaryResponseDTO getChallengeSummary(Long userId);
 
-    ChallengeResultResponseDTO getChallengeResult(Long userId, Long challengeId, String accessToken);
+    ChallengeResultResponseDTO getChallengeResult(Long userId, Long challengeId);
     void confirmChallengeResult(Long userId, Long challengeId);
     boolean hasUnconfirmedResult(Long userId);
 

--- a/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
@@ -10,10 +10,10 @@ import org.scoula.challenge.exception.ChallengeLimitExceededException;
 import org.scoula.challenge.exception.join.*;
 import org.scoula.challenge.mapper.ChallengeMapper;
 import org.scoula.coin.exception.InsufficientCoinException;
-import org.scoula.common.exception.BaseException;
 import org.scoula.coin.mapper.CoinMapper;
+import org.scoula.finance.dto.stock.StockListDto;
+import org.scoula.finance.service.stock.StockService;
 import org.scoula.user.mapper.UserMapper;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,12 +33,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 public class ChallengeServiceImpl implements ChallengeService {
 
-    @Value("${stock.recommend.api.url}")
-    private String stockRecommendApiUrl;
-
     private final ChallengeMapper challengeMapper;
     private final UserMapper userMapper;
     private final CoinMapper coinMapper;
+    private final StockService stockService; // 내부 서비스 직접 호출 (액세스 토큰 전달 제거)
 
     @Override
     public ChallengeCreateResponseDTO createChallenge(Long userId, ChallengeCreateRequestDTO req) {
@@ -308,9 +306,9 @@ public class ChallengeServiceImpl implements ChallengeService {
     }
 
 
-    // 챌린지 결과 확인 관련 로직
+    // 챌린지 결과 확인 관련 로직 + 내부 StockService 직접 호출
     @Override
-    public ChallengeResultResponseDTO getChallengeResult(Long userId, Long challengeId, String accessToken)
+    public ChallengeResultResponseDTO getChallengeResult(Long userId, Long challengeId)
     {
         Challenge challenge = challengeMapper.findChallengeById(challengeId);
         if (challenge == null) throw new ChallengeNotFoundException();
@@ -348,32 +346,26 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         int savedAmount = goal - actual;
 
-        // 🟡 추천 주식 가져오기
+        // 🟡 추천 주식: StockService 직접 호출 (유저 토큰 X)
         StockRecommendationDTO bestStock = null;
         if (savedAmount > 1000) {
-            try {
-                RestTemplate restTemplate = new RestTemplate();
-                HttpHeaders headers = new HttpHeaders();
-                headers.setContentType(MediaType.APPLICATION_JSON);
-                headers.set("Authorization", "Bearer " + accessToken);
+            List<StockListDto> stocks = stockService.getStockRecommendationList(userId, 5, savedAmount);
 
-                HttpEntity<String> entity = new HttpEntity<>(headers);
-                String url = stockRecommendApiUrl + "?priceLimit=" + savedAmount + "&limit=5";
+            // amount 이하에서 가장 비싼 것 선택
+            StockListDto best = stocks.stream()
+                    .filter(s -> s.getStockPrice() > 0 && s.getStockPrice() <= savedAmount) // null 체크 제거, 값 검증만
+                    .max(Comparator.comparingInt(StockListDto::getStockPrice))
+                    .orElse(null);
 
-                ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-                ObjectMapper mapper = new ObjectMapper();
-                String responseBody = response.getBody();
-
-                Map<String, Object> map = mapper.readValue(responseBody, new TypeReference<Map<String, Object>>() {});
-                List<StockRecommendationDTO> stocks = mapper.convertValue(map.get("data"), new TypeReference<List<StockRecommendationDTO>>() {});
-
-                bestStock = stocks.stream()
-                        .filter(stock -> stock.getStockPrice() <= savedAmount)
-                        .max(Comparator.comparingInt(StockRecommendationDTO::getStockPrice))
-                        .orElse(null);
-            } catch (Exception e) {
-                e.printStackTrace(); // 로그 처리
+            if (best != null) {
+                StockRecommendationDTO dto = new StockRecommendationDTO();
+                dto.setStockCode(best.getStockCode());
+                dto.setStockName(best.getStockName());
+                dto.setStockPrice(best.getStockPrice());
+                dto.setStockSummary(best.getStockSummary());
+                bestStock = dto;
             }
+
         }
 
         if (actual < goal) {

--- a/src/main/java/org/scoula/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/scoula/security/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package org.scoula.security.filter;
 
-import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.scoula.common.redis.RedisService;
@@ -19,6 +18,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Locale;
 
 @Component
 @Log4j2
@@ -26,34 +26,46 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
-    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String ACCESS_TOKEN_ATTR = "ACCESS_TOKEN";
 
     private final JwtUtil jwtUtil;
     private final UserDetailsService userDetailsService;
     private final RedisService redisService;
 
-    private Authentication getAuthentication(String token) {
+    private Authentication buildAuthentication(String token) {
+        // subject(email)로 UserDetails 로드 (CustomUserDetails)
         String username = jwtUtil.getEmailFromToken(token);
         UserDetails principal = userDetailsService.loadUserByUsername(username);
         return new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
     }
 
+    private String resolveBearerToken(String header) {
+        if (header == null) return null;
+        // 대소문자/공백 안전 처리
+        String lower = header.toLowerCase(Locale.ROOT).trim();
+        if (!lower.startsWith("bearer ")) return null;
+        return header.substring(7).trim();
+    }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        String bearerHeader = request.getHeader(AUTHORIZATION_HEADER);
+        String token = resolveBearerToken(bearerHeader);
 
-        if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
-            String token = bearerToken.substring(BEARER_PREFIX.length());
-
-            //블랙리스트에 등록된 access 토큰인 경우 예외처리
-            if(redisService.isTokenBlacklisted(token)){
+        if (token != null) {
+            // 블랙리스트 체크
+            if (redisService.isTokenBlacklisted(token)) {
                 throw new BlackListException("블랙리스트에 등록된 토큰입니다.");
             }
 
+            // 유효 토큰이면 SecurityContext 세팅
             if (jwtUtil.validateToken(token)) {
-                Authentication authentication = getAuthentication(token);
+                Authentication authentication = buildAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                // 컨트롤러에서 필요할 수 있는 원본 액세스 토큰을 요청 속성에 저장
+                request.setAttribute(ACCESS_TOKEN_ATTR, token);
             }
         }
 


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약

* JWT 액세스 토큰 전달 방식을 `@AuthenticationPrincipal` 기반으로 통일하여 보안성 및 유지보수성 개선
* 주식 추천 로직에서 외부 API 호출 제거, 내부 `StockService` 호출로 변경
* 증권 API 토큰 발급 및 재시도 로직을 `StockServiceImpl`에서 일원화
* 추천 주식 로직의 불필요한 null 비교 오류 수정

## 📖 작업 내용

* **ChallengeController / ChallengeServiceImpl**

  * `accessToken` 파라미터 제거 및 컨트롤러에서 `userId`만 서비스로 전달
  * 외부 증권 API 직접 호출 제거, 내부 `StockService` 호출로 변경
* **StockServiceImpl**

  * 사용자 증권 API 토큰 조회/검증/재발급 로직 통합 (`sendPostRequestWithUserId` 메서드)
  * 401·419 응답 시 토큰 재발급 후 1회 재시도, 429 응답 시 지수 백오프 적용
* **추천 주식 로직 개선**

  * int 타입의 불필요한 null 비교 제거
  * `price > 0 && price <= savedAmount` 조건을 만족하는 종목 중 최댓값 선정

## ✅ 체크리스트

* [x] 커밋 컨벤션 준수
* [x] 로컬 환경에서 동작 확인 완료
* [x] 리뷰어 n명 이상 승인 완료
* [x] 문서화가 필요한 경우 추가했습니다.
* [x] 관련 이슈가 있다면 연결했습니다.

## ✋ 질문 사항

- 시큐리티 허용 URI 설정 수정도 필요함

## 🔗 관련 이슈

- closes #148 
