### PR TITLE
feat: 완료된 챌린지 히스토리 조회 API 추가

### DIFF
--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -108,4 +108,14 @@ public class ChallengeController {
         boolean result = challengeService.hasUnconfirmedResult(userId);
         return CommonResponseDTO.success("미확인 결과 존재 여부 확인", result);
     }
+
+    @GetMapping("/history")
+    public CommonResponseDTO<List<ChallengeHistoryItemDTO>> getChallengeHistory(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        List<ChallengeHistoryItemDTO> list = challengeService.getChallengeHistory(userId);
+        return CommonResponseDTO.success("챌린지 히스토리 조회 성공", list);
+    }
+
 }

--- a/src/main/java/org/scoula/challenge/dto/ChallengeHistoryItemDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeHistoryItemDTO.java
@@ -1,0 +1,31 @@
+package org.scoula.challenge.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.scoula.challenge.enums.ChallengeType;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeHistoryItemDTO {
+    private Long challengeId;
+    private String title;
+    private String categoryName;
+
+    private ChallengeType type;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    private Boolean isSuccess;           // user_challenge.is_success (NULL 가능)
+    private Boolean isCompleted;         // 항상 true (is_completed=1만 조회)
+    private Integer actualValue;         // 내 실제 소비값
+    private Integer goalValue;           // 목표값 (challenge.goal_value)
+    private Integer actualRewardPoint;   // 지급 포인트
+    private Boolean resultChecked;       // 결과 확인 여부
+    private LocalDate completedAt;   // user_challenge.updated_at
+}

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -7,6 +7,7 @@ import org.scoula.challenge.dto.ChallengeMemberDTO;
 import org.scoula.challenge.dto.ChallengeSummaryResponseDTO;
 import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
+import org.scoula.challenge.dto.ChallengeHistoryItemDTO;
 
 import java.util.List;
 
@@ -85,5 +86,6 @@ public interface ChallengeMapper {
                                @Param("challengeId") Long challengeId,
                                @Param("actualRewardPoint") int actualRewardPoint);
 
+    List<ChallengeHistoryItemDTO> findCompletedHistoryByUser(@Param("userId") Long userId);
 }
 

--- a/src/main/java/org/scoula/challenge/service/ChallengeService.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeService.java
@@ -16,5 +16,5 @@ public interface ChallengeService {
     ChallengeResultResponseDTO getChallengeResult(Long userId, Long challengeId);
     void confirmChallengeResult(Long userId, Long challengeId);
     boolean hasUnconfirmedResult(Long userId);
-
+    List<ChallengeHistoryItemDTO> getChallengeHistory(Long userId);
 }

--- a/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
@@ -400,5 +400,10 @@ public class ChallengeServiceImpl implements ChallengeService {
         return challengeMapper.existsUnconfirmedCompletedChallenge(userId);
     }
 
+    @Override
+    public List<ChallengeHistoryItemDTO> getChallengeHistory(Long userId) {
+        return challengeMapper.findCompletedHistoryByUser(userId);
+    }
+
 }
 

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -202,5 +202,31 @@
         WHERE user_id = #{userId} AND challenge_id = #{challengeId}
     </update>
 
+    <!-- 완료된(is_completed=1) 챌린지 히스토리: resultType 그대로 사용 -->
+    <select id="findCompletedHistoryByUser" resultType="org.scoula.challenge.dto.ChallengeHistoryItemDTO">
+        SELECT
+            uc.challenge_id              AS challengeId,
+            c.title                      AS title,
+            cc.name                      AS categoryName,
+            c.type                       AS type,
+            c.start_date                 AS startDate,
+            c.end_date                   AS endDate,
+            uc.is_success                AS isSuccess,
+            uc.is_completed              AS isCompleted,
+            uc.actual_value              AS actualValue,
+            c.goal_value                 AS goalValue,
+            uc.actual_reward_point       AS actualRewardPoint,
+            uc.result_checked            AS resultChecked,
+            DATE(uc.updated_at)          AS completedAt     -- ✅ LocalDate 매핑용으로 DATE() 처리
+        FROM user_challenge uc
+            JOIN challenge c
+        ON uc.challenge_id = c.id
+            LEFT JOIN challenge_category cc
+            ON c.category_id = cc.id
+        WHERE uc.user_id = #{userId}
+          AND uc.is_completed = 1
+        ORDER BY uc.updated_at DESC
+    </select>
+
 
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

로그인한 유저의 완료된 챌린지 히스토리를 조회하는 API 추가 (GET /api/challenge/history)

## 📖 작업 내용 

### DTO
- ChallengeHistoryItemDTO 생성
- completedAt 필드 LocalDate 타입 적용
- Lombok 'NoArgsConstructor' 추가하여 MyBatis 세터 매핑 지원

### Mapper
- findCompletedHistoryByUser 쿼리 작성
- user_challenge + challenge + challenge_category 조인
- is_completed = 1 조건, 최신 완료 순 정렬
- DATE(updated_at)로 LocalDate 변환

### Service
- getChallengeHistory(Long userId) 메서드 구현

### Controller
- /api/challenge/history GET 엔드포인트 추가
- 로그인 유저(AuthenticationPrincipal) 기준 데이터 반환

### 문서화
- 노션 API 명세서에 헤더, 응답 예시, 필드 설명 추가

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- closes #153 
