### PR TITLE
fix: 보안 기본정책 강화 및 OkHttp 연결 누수 수정

### DIFF
--- a/src/main/java/org/scoula/user/util/NicknameGenerator.java
+++ b/src/main/java/org/scoula/user/util/NicknameGenerator.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Random;
 import java.util.UUID;
 
@@ -19,17 +20,25 @@ public class NicknameGenerator {
     @Value("${gpt.api.key}")
     private String apiKey;
 
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    // ✅ 1) OkHttpClient는 앱 전역에서 재사용 (스레드세이프)
+    private static final OkHttpClient CLIENT = new OkHttpClient.Builder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .readTimeout(Duration.ofSeconds(15))
+            .writeTimeout(Duration.ofSeconds(10))
+            .build();
+
     private final String[] fallbackVerbs = {"코딩하는", "주식하는", "청약하는", "절약하는", "분석하는"};
     private final String[] fallbackNouns = {"토끼", "부엉이", "호랑이", "모몽가", "너구리", "펭귄", "도치", "햄스터"};
     private final Random random = new Random();
 
     public String generateNickname() {
         try {
-            OkHttpClient client = new OkHttpClient();
-
             String prompt = "랜덤한 {동사}하는{동물 또는 캐릭터} 형태의 한국어 닉네임을 한 개만 출력해줘. 예: '코딩하는토끼'";
+
             JSONObject requestBody = new JSONObject()
-                    .put("model", "gpt-4o")  // 또는 gpt-4o-mini
+                    .put("model", "gpt-4o")  // 필요시 gpt-4o-mini
                     .put("messages", new org.json.JSONArray()
                             .put(new JSONObject()
                                     .put("role", "user")
@@ -42,28 +51,31 @@ public class NicknameGenerator {
                     .url("https://api.openai.com/v1/chat/completions")
                     .addHeader("Authorization", "Bearer " + apiKey)
                     .addHeader("Content-Type", "application/json")
-                    .post(RequestBody.create(requestBody.toString(), MediaType.parse("application/json")))
+                    .post(RequestBody.create(requestBody.toString(), JSON))
                     .build();
 
-            Response response = client.newCall(request).execute();
+            // ✅ 2) try-with-resources로 Response를 반드시 닫기
+            try (Response response = CLIENT.newCall(request).execute()) {
+                if (!response.isSuccessful()) {
+                    log.warn("🔴 GPT 응답 실패 - status: {}", response.code());
+                    throw new IOException("GPT API 응답 실패: " + response.code());
+                }
 
-            if (!response.isSuccessful()) {
-                log.warn("🔴 GPT 응답 실패 - status: {}", response.code());
-                throw new IOException("GPT API 응답 실패: " + response.code());
+                // body.string()을 호출하면 ResponseBody는 소모되며 자동 close 되지만,
+                // try-with-resources로 Response 전체를 닫는 게 가장 안전.
+                String body = response.body().string();
+                log.debug("🟢 GPT 응답 원본: {}", body);
+
+                JSONObject responseBody = new JSONObject(body);
+                String result = responseBody.getJSONArray("choices")
+                        .getJSONObject(0)
+                        .getJSONObject("message")
+                        .getString("content");
+
+                String cleaned = result.replaceAll("[^가-힣a-zA-Z0-9]", "").trim();
+                log.info("🟢 GPT 닉네임 생성 성공: {}", cleaned);
+                return cleaned;
             }
-
-            String body = response.body().string();
-            log.debug("🟢 GPT 응답 원본: {}", body);
-
-            JSONObject responseBody = new JSONObject(body);
-            String result = responseBody.getJSONArray("choices")
-                    .getJSONObject(0)
-                    .getJSONObject("message")
-                    .getString("content");
-
-            String cleaned = result.replaceAll("[^가-힣a-zA-Z0-9]", "").trim();
-            log.info("🟢 GPT 닉네임 생성 성공: {}", cleaned);
-            return cleaned;
 
         } catch (IOException e) {
             log.error("🔻 GPT 호출 실패 - fallback 닉네임 생성으로 대체: {}", e.getMessage());


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약

스프링 시큐리티 기본 정책을 강화하고, OkHttp 응답 자원 미해제로 인한 `connection leaked` 경고를 해결했습니다.
공개 API 화이트리스트를 명확히 하고 로그인 필터 URL을 고정하여 불필요한 인증 시도를 방지했습니다.

## 📖 작업 내용

* **SecurityConfig**

  * 공개 허용 경로(permitAll) 명시

    * POST `/api/user/signup`
    * GET `/api/user/email-check`
    * POST `/api/user/password-reset`
    * POST `/api/auth/login`
    * GET `/api/auth/test-login`
  * `JwtEmailPasswordAuthenticationFilter.setFilterProcessesUrl("/api/auth/login")` 적용
  * `anyRequest().authenticated()`로 기본 차단 정책 적용
  * `web.ignoring` 최소화(정적/Swagger/favicon만 제외)
  * CORS에 프론트 도메인만 허용(와일드카드 제거), credentials=true 시 브라우저 제약 대응
  * CSRF 비활성화 유지 → 프론트의 `/csrf` 호출 불필요
* **NicknameGenerator**

  * OkHttpClient 싱글턴 재사용으로 커넥션 재활용
  * try-with-resources로 Response/Body를 안전하게 close → connection leaked 경고 제거
  * 타임아웃 설정 추가(connect/read/write)
* **기타**

  * favicon 404 로그 소음 감소(ignore 추가)
  * FE 라우팅 소음(`/index`, `/favicon.ico`) 제거용 Nginx SPA fallback + `/api` 프록시 권장사항 문서화

## ✅ 체크리스트

* [ ] 커밋 컨벤션 준수
* [ ] 로컬 환경에서 동작 확인 완료
* [ ] 리뷰어 n명 이상 승인 완료
* [ ] 문서화가 필요한 경우 추가했습니다.
* [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

* 운영 환경에서 CORS 허용 도메인 범위를 스테이징/운영 분리 적용할지 여부
* 로그인 필터 URL 변경에 따른 프론트 호출 경로 변경이 완료되었는지 확인 필요

## 🔗 관련 이슈

* closes #164 
