### PR TITLE
fix: 스케줄러 테스트용 API SecurityConfig에 permitAll 경로 추가

### DIFF
--- a/src/main/java/org/scoula/security/config/SecurityConfig.java
+++ b/src/main/java/org/scoula/security/config/SecurityConfig.java
@@ -130,6 +130,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
                     .antMatchers(HttpMethod.POST,  "/api/auth/test-login").permitAll()
 
+                    .antMatchers(HttpMethod.GET, "/api/challenge/scheduler/**").permitAll()
+
                     // 그 외는 기본 차단(로그인 필요)
                     .anyRequest().authenticated()
 


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 
- SecurityConfig에 스케줄러 테스트용 API 호출 허용 경로 추가

## 📖 작업 내용 
- `/api/challenge/scheduler/**` GET 요청을 permitAll()로 설정

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- closes #168
