### PR TITLE
feat: JWT 인증 실패 원인 추적 로깅 강화 및 공개 경로 필터 제외 처리

### DIFF
--- a/src/main/java/org/scoula/security/config/SecurityConfig.java
+++ b/src/main/java/org/scoula/security/config/SecurityConfig.java
@@ -77,6 +77,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
 
+        config.setExposedHeaders(List.of("Authorization"));
+
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);
     }
@@ -129,6 +131,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers(HttpMethod.POST, "/api/user/password-reset").permitAll()
                     .antMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
                     .antMatchers(HttpMethod.POST,  "/api/auth/test-login").permitAll()
+                    .antMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
 
                     .antMatchers(HttpMethod.GET, "/api/challenge/scheduler/**").permitAll()
 

--- a/src/main/java/org/scoula/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/scoula/security/filter/JwtAuthenticationFilter.java
@@ -3,7 +3,6 @@ package org.scoula.security.filter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.scoula.common.redis.RedisService;
-import org.scoula.security.Exception.BlackListException;
 import org.scoula.security.util.JwtUtil;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -27,46 +26,110 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String ACCESS_TOKEN_ATTR = "ACCESS_TOKEN";
+    private static final String AUTH_EXCEPTION_ATTR = "auth_exception_message"; // ★ 추가
 
     private final JwtUtil jwtUtil;
     private final UserDetailsService userDetailsService;
     private final RedisService redisService;
 
     private Authentication buildAuthentication(String token) {
-        // subject(email)로 UserDetails 로드 (CustomUserDetails)
-        String username = jwtUtil.getEmailFromToken(token);
+        String username = jwtUtil.getEmailFromToken(token); // subject(email)
         UserDetails principal = userDetailsService.loadUserByUsername(username);
         return new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
     }
 
     private String resolveBearerToken(String header) {
         if (header == null) return null;
-        // 대소문자/공백 안전 처리
         String lower = header.toLowerCase(Locale.ROOT).trim();
         if (!lower.startsWith("bearer ")) return null;
         return header.substring(7).trim();
     }
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        // OPTIONS 프리플라이트, 로그인/리프레시/스웨거/정적/스케줄러 등 공개 엔드포인트
+        return "OPTIONS".equalsIgnoreCase(request.getMethod())
+                || uri.startsWith("/api/auth/login")
+                || uri.startsWith("/api/auth/test-login")
+                || uri.startsWith("/api/auth/refresh")
+                || uri.startsWith("/swagger") || uri.startsWith("/v2") || uri.startsWith("/v3")
+                || uri.startsWith("/webjars") || uri.startsWith("/assets")
+                || uri.startsWith("/api/challenge/scheduler/");
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String bearerHeader = request.getHeader(AUTHORIZATION_HEADER);
+        final String uri = request.getRequestURI();
+        final String bearerHeader = request.getHeader(AUTHORIZATION_HEADER);
+
+        // 1) 헤더 로깅
+        if (bearerHeader == null) {
+            log.debug("[JWT] Authorization 헤더 없음: uri={}", uri);
+        } else {
+            log.debug("[JWT] Authorization 헤더 수신: uri={}, 앞 20자={}",
+                    uri, bearerHeader.substring(0, Math.min(bearerHeader.length(), 20)));
+        }
+
+        // 2) Bearer 토큰 파싱
         String token = resolveBearerToken(bearerHeader);
+        if (token == null) {
+            // 헤더는 있으나 형식이 잘못됐을 수도 있으니 메시지 남김
+            if (bearerHeader != null) {
+                log.warn("[JWT] Bearer 형식 오류: uri={}, header 앞 20자={}",
+                        uri, bearerHeader.substring(0, Math.min(bearerHeader.length(), 20)));
+                request.setAttribute(AUTH_EXCEPTION_ATTR, "Authorization 헤더 형식 오류(Bearer 필요)");
+            }
+            filterChain.doFilter(request, response);
+            return;
+        }
 
-        if (token != null) {
-            // 블랙리스트 체크
+        // 3) 블랙리스트 체크
+        try {
             if (redisService.isTokenBlacklisted(token)) {
-                throw new BlackListException("블랙리스트에 등록된 토큰입니다.");
+                log.error("[JWT] 블랙리스트 토큰: uri={}", uri);
+                request.setAttribute(AUTH_EXCEPTION_ATTR, "블랙리스트에 등록된 토큰입니다.");
+                filterChain.doFilter(request, response);
+                return;
             }
+        } catch (Exception e) {
+            // Redis 통신 이슈 등
+            log.error("[JWT] 블랙리스트 확인 실패: uri={}, msg={}", uri, e.getMessage());
+            request.setAttribute(AUTH_EXCEPTION_ATTR, "인증 처리 중 오류(블랙리스트 확인 실패)");
+            filterChain.doFilter(request, response);
+            return;
+        }
 
-            // 유효 토큰이면 SecurityContext 세팅
-            if (jwtUtil.validateToken(token)) {
-                Authentication authentication = buildAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+        // 4) 유효성 검사
+        boolean valid = false;
+        try {
+            valid = jwtUtil.validateToken(token);
+        } catch (Exception e) {
+            // JwtUtil 내부에서 만료/서명오류 등 던지면 여기서 잡아 로그
+            log.error("[JWT] 토큰 검증 예외: uri={}, msg={}", uri, e.getMessage());
+            request.setAttribute(AUTH_EXCEPTION_ATTR, "유효하지 않은 토큰: " + e.getMessage());
+        }
 
-                // 컨트롤러에서 필요할 수 있는 원본 액세스 토큰을 요청 속성에 저장
-                request.setAttribute(ACCESS_TOKEN_ATTR, token);
+        if (!valid) {
+            if (request.getAttribute(AUTH_EXCEPTION_ATTR) == null) {
+                log.warn("[JWT] 토큰 검증 실패: uri={}", uri);
+                request.setAttribute(AUTH_EXCEPTION_ATTR, "유효하지 않은 토큰입니다.");
             }
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 5) 인증 컨텍스트 설정
+        try {
+            Authentication authentication = buildAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            request.setAttribute(ACCESS_TOKEN_ATTR, token);
+            log.debug("[JWT] 인증 컨텍스트 설정 성공: uri={}", uri);
+        } catch (Exception e) {
+            log.error("[JWT] 인증 컨텍스트 설정 실패: uri={}, msg={}", uri, e.getMessage());
+            request.setAttribute(AUTH_EXCEPTION_ATTR, "인증 컨텍스트 설정 실패: " + e.getMessage());
+            // 컨텍스트 없이 진행 → 보호자원에서 EntryPoint가 401
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/org/scoula/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/scoula/security/handler/CustomAuthenticationEntryPoint.java
@@ -17,7 +17,23 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
+        String auth = request.getHeader("Authorization");
+
         log.error("========== 인증 에러 ============");
-        JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, authException.getMessage());
+        log.error("요청 URI: {}", request.getRequestURI());
+        log.error("Authorization 헤더 존재 여부: {}", (auth != null));
+        log.error("Authorization 헤더 값(앞 20자): {}",
+                auth != null ? auth.substring(0, Math.min(auth.length(), 20)) : "null");
+        log.error("예외 메시지: {}", authException != null ? authException.getMessage() : "null");
+
+        // 🔸 필터에서 넘긴 상세 사유가 있으면 그걸 우선 사용
+        String detail = (String) request.getAttribute("auth_exception_message");
+        String message = (detail != null)
+                ? detail
+                : (authException != null ? authException.getMessage() : "unknown");
+
+        JsonResponse.sendError(response, HttpStatus.UNAUTHORIZED, "인증 실패: " + message);
     }
+
+
 }


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약
JWT 인증 실패 시 원인을 명확히 파악할 수 있도록 서버 로그와 응답 메시지를 강화하고, 공개 경로에서는 불필요한 JWT 필터 검사를 제외하도록 개선했습니다.

## 📖 작업 내용
- **인증 실패 로깅 강화**
  - CustomAuthenticationEntryPoint에 요청 URI, Authorization 헤더 존재 여부/값 일부, 예외 메시지 로깅 추가
  - 필터에서 설정한 auth_exception_message를 우선 사용하여 응답 메시지에 상세 사유 포함
- **JwtAuthenticationFilter 개선**
  - 토큰 없음, 형식 오류, 블랙리스트, 검증 실패, 컨텍스트 실패 등 상황별로 로그 및 상세 사유 설정
  - request attribute를 통해 EntryPoint로 실패 사유 전달
  - shouldNotFilter 구현으로 공개 경로(API 로그인, 토큰 재발급, Swagger, 정적 리소스, 스케줄러) 요청 시 필터 스킵
- **SecurityConfig 수정**
  - /api/auth/refresh permitAll 추가
  - CORS exposedHeaders에 Authorization 추가

## ✅ 체크리스트
- [x] JWT 인증 실패 사유가 서버 로그와 응답에 명확히 표시됨
- [x] 공개 경로에서 불필요한 JWT 필터 검사 수행 안 함
- [x] CORS 및 Security permit 설정 검증 완료
- [x] 로컬 환경에서 정상 동작 확인

## ✋ 질문 사항
- 현재 auth_exception_message에 담기는 상세 사유를 운영 환경에서도 그대로 응답에 내려도 되는지(보안 정책 확인 필요)
- shouldNotFilter에 포함된 경로 외에 추가로 제외할 엔드포인트가 있는지

## 🔗 관련 이슈
- closes #171 
