### PR TITLE
feat: 월별 누적 포인트 조회 API 추가

### DIFF
--- a/src/main/java/org/scoula/coin/controller/CoinController.java
+++ b/src/main/java/org/scoula/coin/controller/CoinController.java
@@ -1,0 +1,29 @@
+package org.scoula.coin.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.scoula.coin.dto.CoinMonthlyResponseDTO;
+import org.scoula.coin.service.CoinService;
+import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.security.account.domain.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coin")
+public class CoinController {
+
+    private final CoinService coinService;
+
+    // 이달 누적 포인트
+    @GetMapping("/monthly")
+    public CommonResponseDTO<CoinMonthlyResponseDTO> getMyMonthlyCoin(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Long userId = user.getUserId();
+        CoinMonthlyResponseDTO dto = coinService.getMyMonthlyCoin(userId);
+        return CommonResponseDTO.success("월별 누적 포인트 조회 성공", dto);
+    }
+}

--- a/src/main/java/org/scoula/coin/dto/CoinMonthlyResponseDTO.java
+++ b/src/main/java/org/scoula/coin/dto/CoinMonthlyResponseDTO.java
@@ -1,0 +1,14 @@
+package org.scoula.coin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data @Builder
+@AllArgsConstructor @NoArgsConstructor
+public class CoinMonthlyResponseDTO {
+    private String month;     // 예: "2025-08"
+    private long amount;      // 이달 누적 포인트
+    private String updatedAt; // 최근 갱신 시각 (선택)
+}

--- a/src/main/java/org/scoula/coin/mapper/CoinMapper.java
+++ b/src/main/java/org/scoula/coin/mapper/CoinMapper.java
@@ -17,5 +17,9 @@ public interface CoinMapper {
 
     //누적포인트 조회
     int getCumulativeAmount(@Param("userId") Long userId);
+
+    // 챌린지 홈 슬라이드에서 활용 월별 누적데이터
+    Long getMonthlyCumulativeAmount(@Param("userId") Long userId);
+    String getUpdatedAt(@Param("userId") Long userId);
 }
 

--- a/src/main/java/org/scoula/coin/service/CoinService.java
+++ b/src/main/java/org/scoula/coin/service/CoinService.java
@@ -1,0 +1,7 @@
+package org.scoula.coin.service;
+
+import org.scoula.coin.dto.CoinMonthlyResponseDTO;
+
+public interface CoinService {
+    CoinMonthlyResponseDTO getMyMonthlyCoin(Long userId);
+}

--- a/src/main/java/org/scoula/coin/service/CoinServiceImpl.java
+++ b/src/main/java/org/scoula/coin/service/CoinServiceImpl.java
@@ -1,0 +1,30 @@
+package org.scoula.coin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.coin.dto.CoinMonthlyResponseDTO;
+import org.scoula.coin.mapper.CoinMapper;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class CoinServiceImpl implements CoinService {
+
+    private final CoinMapper coinMapper;
+
+    @Override
+    public CoinMonthlyResponseDTO getMyMonthlyCoin(Long userId) {
+        Long amount = coinMapper.getMonthlyCumulativeAmount(userId);
+        String updatedAt = coinMapper.getUpdatedAt(userId);
+
+        String month = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+
+        return CoinMonthlyResponseDTO.builder()
+                .month(month)
+                .amount(amount == null ? 0L : amount)
+                .updatedAt(updatedAt)
+                .build();
+    }
+}

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -74,6 +74,7 @@ import javax.sql.DataSource;
         "org.scoula.challenge.rank.util",
         "org.scoula.common.aop",
         "org.scoula.summary.service",
+        "org.scoula.coin.service"
         })
 @EnableTransactionManagement
 @EnableAspectJAutoProxy

--- a/src/main/java/org/scoula/config/ServletConfig.java
+++ b/src/main/java/org/scoula/config/ServletConfig.java
@@ -42,7 +42,8 @@ import java.util.List;
         "org.scoula.monthreport.controller",
         "org.scoula.agree.controller",
         "org.scoula.challenge.rank.controller",
-        "org.scoula.summary.controller"
+        "org.scoula.summary.controller",
+        "org.scoula.coin.controller"
 })
 public class ServletConfig implements WebMvcConfigurer {
 

--- a/src/main/resources/org/scoula/coin/mapper/CoinMapper.xml
+++ b/src/main/resources/org/scoula/coin/mapper/CoinMapper.xml
@@ -37,4 +37,16 @@
         SELECT cumulative_amount from coin where id=#{userId}
     </select>
 
+    <select id="getMonthlyCumulativeAmount" resultType="long">
+        SELECT COALESCE(monthly_cumulative_amount, 0)
+        FROM coin
+        WHERE id = #{userId}
+    </select>
+
+    <select id="getUpdatedAt" resultType="string">
+        SELECT DATE_FORMAT(updated_at, '%Y-%m-%d %H:%i:%s')
+        FROM coin
+        WHERE id = #{userId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request
## 👀 작업 요약
월별 누적 포인트 조회 API (GET /api/coin/monthly) 추가

## 📖 작업 내용

- Controller: CoinController#getMyMonthlyCoin 신설
- Service/Impl: CoinService#getMyMonthlyCoin 구현
- Mapper/Xml: getMonthlyCumulativeAmount, getUpdatedAt 쿼리 추가
- 응답 DTO: CoinMonthlyResponseDTO { month, amount, updatedAt }


## 기타

- 공통 응답 포맷(CommonResponseDTO) 유지
- 인증: @AuthenticationPrincipal로 로그인 사용자 식별

## ✅ 체크리스트
 커밋 컨벤션 준수 (feat/fix 등)

 로컬에서 API 정상 동작 (200 응답)

 401/403/500 에러 핸들링 확인

 문서화(아래 API 명세) 반영

 관련 이슈 연결 (예: Closes #123)

## ✋ 질문 사항
monthly_cumulative_amount가 월 초(또는 스냅샷 시점)에 0으로 리셋되는 스케줄이 운영 중인지 확인 필요
합본 홈 API(/api/challenge/home)로의 통합 계획이 있다면 추후 리팩토링 논의

🔗 관련 이슈
Closes #175 