### PR TITLE
feat: 토큰 발급 방식을 쿠키/헤더 기반으로 전면 전환

### DIFF
--- a/src/main/java/org/scoula/security/config/SecurityConfig.java
+++ b/src/main/java/org/scoula/security/config/SecurityConfig.java
@@ -68,12 +68,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowCredentials(true);
+
         // TODO: 실제 프론트 도메인으로 교체
         config.setAllowedOrigins(List.of(
                 "http://localhost:5173"
         ));
 
-        config.addAllowedOriginPattern("*");
+        // config.addAllowedOriginPattern("*");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
 

--- a/src/main/java/org/scoula/security/util/CookieUtil.java
+++ b/src/main/java/org/scoula/security/util/CookieUtil.java
@@ -1,0 +1,36 @@
+package org.scoula.security.util;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+    public static void addHttpOnlyCookie(HttpServletResponse resp, String name, String value,
+                                         int maxAgeSeconds, boolean secure, String sameSite) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(name).append("=").append(value)
+                .append("; Path=/")
+                .append("; Max-Age=").append(maxAgeSeconds)
+                .append("; HttpOnly");
+        if (secure) sb.append("; Secure");
+        if (sameSite != null) sb.append("; SameSite=").append(sameSite);
+        resp.addHeader("Set-Cookie", sb.toString());
+    }
+
+    /** 개발/운영 환경에 맞춘 삭제(secure/sameSite 지정) */
+    public static void deleteCookie(HttpServletResponse resp, String name,
+                                    boolean secure, String sameSite) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(name).append("=").append("")
+                .append("; Path=/")
+                .append("; Max-Age=0")
+                .append("; HttpOnly");
+        if (secure) sb.append("; Secure");
+        if (sameSite != null) sb.append("; SameSite=").append(sameSite);
+        resp.addHeader("Set-Cookie", sb.toString());
+    }
+
+    /** 간편 삭제(Lax, secure=false) — 개발 기본값 */
+    public static void deleteCookie(HttpServletResponse resp, String name) {
+        deleteCookie(resp, name, false, "Lax");
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

JWT 토큰 발급·재발급 방식을 쿠키 기반(RT) + 헤더 기반(AT)으로 변경하여 보안성과 표준성을 강화

## 📖 작업 내용 

### 로그인 API
- Refresh Token → httpOnly 쿠키로 전달
- Access Token → Authorization 헤더로 전달

### 토큰 재발급 API (/auth/refresh)
- 요청 시 브라우저에서 RT 자동 전송
- 응답에서 AT는 Authorization 헤더로만 전달

### CORS 설정 수정
- allowCredentials(true) 적용
- http://localhost:5173 허용
- SameSite=Lax, Secure=false로 환경에 맞게 쿠키 설정

기존 JSON 응답의 토큰 필드 제거
프론트에서 RT를 JS로 접근하지 않도록 구조 변경 대비

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- closes #176 
