### PR TITLE
feat: 뉴스 응답값에 검색키워드 추가

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -38,10 +38,11 @@ CREATE TABLE `investment_types` (
                                     `id` BIGINT NOT NULL,
                                     `total_score` INT NOT NULL,
                                     `propensity_type` VARCHAR(255) NOT NULL,
-                                    `question1` ENUM('A','B','C') NOT NULL,
-                                    `question2` ENUM('A','B','C') NOT NULL,
-                                    `question3` ENUM('A','B','C') NOT NULL,
-                                    `question4` ENUM('A','B','C') NOT NULL,
+                                    `question1` VARCHAR(255) NOT NULL,
+                                    `question2` VARCHAR (255) NOT NULL,
+                                    `question3` VARCHAR(255) NOT NULL,
+                                    `question4` VARCHAR(255)NOT NULL,
+                                    `question5` VARCHAR(255) NOT NULL,
                                     PRIMARY KEY (`id`),
                                     FOREIGN KEY (`id`) REFERENCES `user`(`id`) ON DELETE CASCADE
 );
@@ -594,6 +595,7 @@ CREATE TABLE `finpik` (
                           `summary` TEXT NOT NULL,
                           `link` VARCHAR(500) NOT NULL,
                           `published_at` DATETIME NOT NULL,
+                          `keyword` VARCHAR(255) NOT NULL,
                           PRIMARY KEY (`id`)
 );
 

--- a/src/main/java/org/scoula/news/domain/NewsVO.java
+++ b/src/main/java/org/scoula/news/domain/NewsVO.java
@@ -12,4 +12,5 @@ public class NewsVO {
     private String link;
     private String summary;
     private LocalDateTime publishedAt;
+    private String keyword;
 }

--- a/src/main/java/org/scoula/news/dto/NaverNewsResponseDTO.java
+++ b/src/main/java/org/scoula/news/dto/NaverNewsResponseDTO.java
@@ -19,9 +19,9 @@ public class NaverNewsResponseDTO {
     private int display;          // 한 번에 표시할 검색 결과 개수
     private List<Item> items;     // 검색 결과 뉴스 아이템 목록
 
-    public List<NewsVO> toVO() {
+    public List<NewsDTO> toDTO() {
         return this.items.stream()
-                .map(Item::toNewsVO) // 각 Item을 NewsVO로 변환
+                .map(Item::toNewsDTO) // 각 Item을 NewsDTO로 변환
                 .collect(Collectors.toList()); // 리스트로 수집
     }
 
@@ -33,7 +33,7 @@ public class NaverNewsResponseDTO {
         private String description;  // 뉴스 요약 (HTML 태그 포함 가능)
         private String pubDate;      // 뉴스 발행일 (RFC 2822 형식)
 
-        public NewsVO toNewsVO() {
+        public NewsDTO toNewsDTO() {
 
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
             LocalDateTime parsePubDate=LocalDateTime.parse(this.pubDate,formatter);
@@ -43,13 +43,20 @@ public class NaverNewsResponseDTO {
 
             String cleanTitle = unescapedTitle.replaceAll("<[^>]*>", "");
             String cleanDescription = unescapedDescription.replaceAll("<[^>]*>", "");
+//
+//            NewsVO newsVO = new NewsVO();
+//            newsVO.setTitle(cleanTitle);
+//            newsVO.setLink(this.originallink);
+//            newsVO.setSummary(cleanDescription);
+//            newsVO.setPublishedAt(parsePubDate);
 
-            NewsVO newsVO = new NewsVO();
-            newsVO.setTitle(cleanTitle);
-            newsVO.setLink(this.originallink);
-            newsVO.setSummary(cleanDescription);
-            newsVO.setPublishedAt(parsePubDate);
-            return newsVO;
+            return NewsDTO.builder()
+                    .title(cleanTitle)
+                    .keyword(null)
+                    .publishedAt(parsePubDate)
+                    .summary(cleanDescription)
+                    .link(this.originallink)
+                    .build();
         }
     }
 }

--- a/src/main/java/org/scoula/news/dto/NewsDTO.java
+++ b/src/main/java/org/scoula/news/dto/NewsDTO.java
@@ -20,6 +20,7 @@ public class NewsDTO {
     private String summary;
     private String link;
     private LocalDateTime publishedAt;
+    private String keyword;
 
 
     public static NewsDTO of(NewsVO newsVO){
@@ -30,6 +31,18 @@ public class NewsDTO {
                 .summary(newsVO.getSummary())
                 .link(newsVO.getLink())
                 .publishedAt(newsVO.getPublishedAt())
+                .keyword(newsVO.getKeyword())
                 .build();
+    }
+
+    public NewsVO toVO(){
+        NewsVO newsVO = new NewsVO();
+        newsVO.setId(id);
+        newsVO.setTitle(title);
+        newsVO.setSummary(summary);
+        newsVO.setLink(link);
+        newsVO.setPublishedAt(publishedAt);
+        newsVO.setKeyword(keyword);
+        return newsVO;
     }
 }

--- a/src/main/java/org/scoula/news/service/NewsServiceImpl.java
+++ b/src/main/java/org/scoula/news/service/NewsServiceImpl.java
@@ -81,12 +81,29 @@ public class NewsServiceImpl implements NewsService {
                 NaverNewsResponseDTO.class
         ).getBody();
 
+        log.info("네이버 뉴스 API 응답:");
+        log.info(naverNewsResponseDTO);
+
         if(naverNewsResponseDTO==null){
             throw new NullPointerException("네이버 뉴스 API 응답이 null입니다.");
         }
 
-        //new
-        List<NewsVO> newsVOList = naverNewsResponseDTO.toVO();
+
+        //뉴스검색결과를 api호출전용DTO에서 뉴스DTO로 변환
+        List<NewsDTO> newsDTOList = naverNewsResponseDTO.toDTO();
+
+
+        log.info("뉴스DTO변환: ");
+        log.info(newsDTOList);
+
+        List<NewsVO> newsVOList = new ArrayList<>();
+        for(NewsDTO newsDTO : newsDTOList){
+            newsDTO.setKeyword(keyword);
+            newsVOList.add(newsDTO.toVO());
+        }
+
+        log.info("뉴스VO변환: ");
+        log.info(newsVOList);
 
         if (!newsVOList.isEmpty()) { // 삽입할 데이터가 있을 경우에만 호출
             newsMapper.insertNews(newsVOList);

--- a/src/main/resources/org/scoula/news/mapper/NewsMapper.xml
+++ b/src/main/resources/org/scoula/news/mapper/NewsMapper.xml
@@ -5,10 +5,10 @@
 
 <mapper namespace="org.scoula.news.mapper.NewsMapper">
     <insert id="insertNews" parameterType="java.util.List">
-        INSERT INTO finpik (title, summary, link, published_at)
+        INSERT INTO finpik (title, summary, link, published_at, keyword)
         VALUES
         <foreach collection="list" item="news" separator=",">
-            (#{news.title}, #{news.summary}, #{news.link}, #{news.publishedAt})
+            (#{news.title}, #{news.summary}, #{news.link}, #{news.publishedAt},#{news.keyword})
         </foreach>
 
     </insert>


### PR DESCRIPTION

closes #109

# 📌 Pull Request

## 👀 작업 요약 
뉴스 응답값에 검색키워드 추가

## 📖 작업 내용 
네이버 뉴스 기사를 불러올 때 사용한 검색 키워드를 finpickDB에 삽입하도록 설정
이에 맞춰서 DTO, VO에 keyword속성 추가
database.sql, mapper에 keyword 컬럼 추가

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

closes #109 