### PR TITLE
refactor: 계좌/카드 동기화 안정화

### DIFF
--- a/src/main/java/org/scoula/nhapi/dto/NhAccountTransactionResponseDto.java
+++ b/src/main/java/org/scoula/nhapi/dto/NhAccountTransactionResponseDto.java
@@ -24,42 +24,78 @@ public class NhAccountTransactionResponseDto {
     private String category;
     private String analysis;
 
+    // NH JSON → DTO (기존)
     public static NhAccountTransactionResponseDto from(JSONObject obj) {
         return NhAccountTransactionResponseDto.builder()
-                .date(parseDateTime(obj.getString("Trdd"), obj.getString("Txtm")))
+                .date(parseDateTime(obj.optString("Trdd"), obj.optString("Txtm")))
                 .type(parseType(obj.optString("MnrcDrotDsnc")))
-                .amount(new BigDecimal(obj.getString("Tram")))
+                .amount(new BigDecimal(obj.optString("Tram", "0")))
                 .balance(new BigDecimal(obj.optString("AftrBlnc", "0")))
                 .place(obj.optString("Smr", ""))
                 .isCancelled("1".equals(obj.optString("Ccyn")))
-                .tuNo(generateTuNo(obj))
+                .tuNo(generateTuNo(obj)) // 기본 해시
                 .memo(obj.optString("Etct", null))
                 .category(null)
                 .analysis(null)
                 .build();
     }
 
-    private static LocalDateTime parseDateTime(String date, String time) {
+    // NH JSON → DTO (userId/accountId 세팅하고 싶을 때 쓰는 오버로드)
+    public static NhAccountTransactionResponseDto from(JSONObject obj, Long userId, Long accountId) {
+        NhAccountTransactionResponseDto dto = from(obj);
+        dto.setUserId(userId);
+        dto.setAccountId(accountId);
+        // 계좌 단위로 tuNo 범위를 더 안전하게 하고 싶으면 아래 한 줄 켜기
+        // dto.setTuNo(mixTuNoWithAccount(dto.getTuNo(), accountId));
+        return dto;
+    }
+
+    private static LocalDateTime parseDateTime(String yyyymmdd, String hhmmOrHhmmss) {
         try {
-            return LocalDateTime.parse(date + "T" + time + ":00",
-                    DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss"));
+            String date = (yyyymmdd != null && yyyymmdd.length() == 8) ? yyyymmdd :
+                    java.time.LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+
+            String time = (hhmmOrHhmmss == null) ? "000000" : hhmmOrHhmmss.trim();
+            // HHmm → HHmmss 로 보정, HH → HHmmss 도 보정
+            if (time.length() == 4) time = time + "00";
+            else if (time.length() == 2) time = time + "0000";
+            else if (time.length() < 6) time = String.format("%-6s", time).replace(' ', '0');
+            else if (time.length() > 6) time = time.substring(0, 6);
+
+            return LocalDateTime.parse(date + time, DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
         } catch (Exception e) {
             return LocalDateTime.now();
         }
     }
 
     private static String parseType(String code) {
+        // NH 코드 매핑(입금/출금 코드 케이스 추가 가능)
         return switch (code) {
-            case "1", "2" -> "INCOME";
-            case "3", "4" -> "EXPENSE";
+            case "1", "2", "C", "CR" -> "INCOME";
+            case "3", "4", "D", "DR" -> "EXPENSE";
             default -> "EXPENSE";
         };
     }
 
     private static Long generateTuNo(JSONObject obj) {
+        // 날짜/시간/금액/거래처를 이용한 안정 해시 → long
         String key = obj.optString("Trdd") + obj.optString("Txtm")
-                + obj.optString("Tram") + obj.optString("Trnm");
-        return (long) key.hashCode();
+                + obj.optString("Tram") + obj.optString("Trnm", obj.optString("Smr", ""));
+        return toPositiveLongHash(key);
+    }
+
+    // 계좌별로 tuNo 범위를 분리하고 싶을 때 사용
+    private static Long mixTuNoWithAccount(Long base, Long accountId) {
+        long a = (accountId == null) ? 0L : accountId;
+        return (a * 1_000_000_007L) ^ base; // 간단한 도메인 분리
+    }
+
+    private static long toPositiveLongHash(String s) {
+        long h = 1125899906842597L; // prime seed
+        for (int i = 0; i < s.length(); i++) {
+            h = 31*h + s.charAt(i);
+        }
+        return h == Long.MIN_VALUE ? 0 : Math.abs(h);
     }
 
     public boolean isIncome() {

--- a/src/main/java/org/scoula/nhapi/dto/NhCardTransactionResponseDto.java
+++ b/src/main/java/org/scoula/nhapi/dto/NhCardTransactionResponseDto.java
@@ -1,23 +1,78 @@
 package org.scoula.nhapi.dto;
 
+import lombok.Builder;
 import lombok.Data;
+import org.json.JSONObject;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Data
+@Builder
 public class NhCardTransactionResponseDto {
-    private String authNumber;
-    private String salesType;
-    private String approvedAt;
-    private String paymentDate;
-    private BigDecimal amount;
-    private boolean isCancelled;
-    private BigDecimal cancelAmount;
-    private String cancelledAt;
-    private String merchantName;
-    private String tpbcd;
-    private String tpbcdNm;
-    private int installmentMonth;
-    private String currency;
-    private BigDecimal foreignAmount;
+    private String authNumber;           // 승인번호
+    private String salesType;            // 1/2/3/6/7/8
+    private LocalDateTime approvedAt;    // 승인일시
+    private LocalDate paymentDate;       // 결제일(청구일)
+    private BigDecimal amount;           // 승인금액
+    private boolean cancelled;           // 취소 여부
+    private BigDecimal cancelAmount;     // 취소금액
+    private LocalDateTime cancelledAt;   // 취소일시
+    private String merchantName;         // 가맹점명
+    private String tpbcd;                // 업종코드
+    private String tpbcdNm;              // 업종명
+    private int installmentMonth;        // 할부개월
+    private String currency;             // 통화
+    private BigDecimal foreignAmount;    // 해외승인금액
+
+    // NH JSON → DTO 변환(필드명이 다를 수 있어 optString 사용)
+    public static NhCardTransactionResponseDto from(JSONObject obj) {
+        return NhCardTransactionResponseDto.builder()
+                .authNumber(obj.optString("AuthNo", obj.optString("AuthNumber", null)))
+                .salesType(obj.optString("SalesType", obj.optString("Sales_Tp", "1")))
+                .approvedAt(parseDateTime(
+                        obj.optString("AprvDate", obj.optString("ApprovedDate", "")),
+                        obj.optString("AprvTime", obj.optString("ApprovedTime", ""))
+                ))
+                .paymentDate(parseDate(obj.optString("Pymd", obj.optString("PaymentDate", ""))))
+                .amount(new BigDecimal(obj.optString("Amt", obj.optString("Amount", "0"))))
+                .cancelled("1".equals(obj.optString("CnclYn", obj.optString("IsCancelled", "0")))
+                        || obj.optBoolean("IsCancelled", false))
+                .cancelAmount(new BigDecimal(obj.optString("CnclAmt", obj.optString("CancelAmount", "0"))))
+                .cancelledAt(parseDateTime(
+                        obj.optString("CnclDate", obj.optString("CancelledDate", "")),
+                        obj.optString("CnclTime", obj.optString("CancelledTime", ""))
+                ))
+                .merchantName(obj.optString("MchtNm", obj.optString("MerchantName", "")))
+                .tpbcd(obj.optString("Tpbcd", obj.optString("Mcc", "")))
+                .tpbcdNm(obj.optString("TpbcdNm", obj.optString("MccNm", "")))
+                .installmentMonth(obj.optInt("InstMm", obj.optInt("InstallmentMonth", 0)))
+                .currency(obj.optString("Ccy", obj.optString("Currency", "KRW")))
+                .foreignAmount(new BigDecimal(obj.optString("FrnAmt", obj.optString("ForeignAmount", "0"))))
+                .build();
+    }
+
+    private static LocalDateTime parseDateTime(String yyyymmdd, String hhmmss) {
+        try {
+            String d = (yyyymmdd != null && yyyymmdd.length() == 8) ? yyyymmdd : "19700101";
+            String t = (hhmmss == null) ? "000000" : hhmmss.replaceAll("[^0-9]", "");
+            if (t.length() == 4) t += "00";
+            else if (t.length() == 2) t += "0000";
+            else if (t.length() < 6) t = String.format("%-6s", t).replace(' ', '0');
+            else if (t.length() > 6) t = t.substring(0, 6);
+            return LocalDateTime.parse(d + t, DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static LocalDate parseDate(String yyyymmdd) {
+        try {
+            return LocalDate.parse(yyyymmdd, DateTimeFormatter.BASIC_ISO_DATE);
+        } catch (Exception e) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/scoula/nhapi/parser/NhCardParser.java
+++ b/src/main/java/org/scoula/nhapi/parser/NhCardParser.java
@@ -6,7 +6,11 @@ import org.json.JSONObject;
 import org.scoula.nhapi.dto.NhCardTransactionResponseDto;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Slf4j
@@ -21,36 +25,89 @@ public class NhCardParser {
         for (int i = 0; i < recArray.length(); i++) {
             JSONObject obj = recArray.getJSONObject(i);
 
-            NhCardTransactionResponseDto dto = new NhCardTransactionResponseDto();
-            dto.setAuthNumber(obj.optString("AthzNo", null));
-            dto.setSalesType(obj.optString("Stcd", null));
-            dto.setApprovedAt(obj.optString("AthzDtm", null));
-            dto.setPaymentDate(obj.optString("StlmDt", null));
-            dto.setAmount(parseDecimal(obj, "AthzAmt"));
-            dto.setCancelled("Y".equalsIgnoreCase(obj.optString("CancYn")));
-            dto.setCancelAmount(parseDecimal(obj, "CancAmt"));
-            dto.setCancelledAt(obj.optString("CancDtm", null));
-            dto.setMerchantName(obj.optString("MctNm", null));
-            dto.setTpbcd(obj.optString("TpbCd", null));
-            dto.setTpbcdNm(obj.optString("TpbCdNm", null));
-            dto.setInstallmentMonth(obj.optInt("InstMmCnt", 0));
-            dto.setCurrency(obj.optString("FgnCrcyCd", null));
-            dto.setForeignAmount(parseDecimal(obj, "FgnAthzAmt"));
+            NhCardTransactionResponseDto dto = NhCardTransactionResponseDto.builder()
+                    .authNumber(opt(obj, "AthzNo", "AuthNo", "AuthNumber"))
+                    .salesType(opt(obj, "Stcd", "SalesType", "Sales_Tp"))
+                    .approvedAt(parseDateTime(opt(obj, "AthzDtm", "AprvDtm", "ApprovedDateTime", "AthzDateTime")))
+                    .paymentDate(parseDate(opt(obj, "StlmDt", "PaymentDate", "Pymd")))
+                    .amount(parseDecimal(obj, "AthzAmt", "Amt", "ApprovedAmt"))
+                    .cancelled(parseYn(obj, "CancYn", "CnclYn", "IsCancelled"))
+                    .cancelAmount(parseDecimal(obj, "CancAmt", "CancelAmount"))
+                    .cancelledAt(parseDateTime(opt(obj, "CancDtm", "CnclDtm", "CancelledDateTime")))
+                    .merchantName(opt(obj, "MctNm", "MerchantName", "MchtNm"))
+                    .tpbcd(opt(obj, "TpbCd", "Tpbcd", "Mcc"))
+                    .tpbcdNm(opt(obj, "TpbCdNm", "TpbcdNm", "MccNm"))
+                    .installmentMonth(obj.optInt("InstMmCnt", obj.optInt("InstallmentMonth", 0)))
+                    .currency(opt(obj, "FgnCrcyCd", "Currency", "Ccy", "KRW"))
+                    .foreignAmount(parseDecimal(obj, "FgnAthzAmt", "ForeignAmount", "FrnAmt"))
+                    .build();
 
             list.add(dto);
         }
 
+        // 시간 정렬 보장(승인일시가 없다면 그대로)
+        list.sort(Comparator.comparing(NhCardTransactionResponseDto::getApprovedAt,
+                Comparator.nullsLast(Comparator.naturalOrder())));
         return list;
     }
 
-    private static BigDecimal parseDecimal(JSONObject obj, String key) {
+    /* ---------- helpers ---------- */
+
+    private static String opt(JSONObject o, String... keys) {
+        for (String k : keys) {
+            String v = o.optString(k, null);
+            if (v != null && !v.isEmpty()) return v;
+        }
+        return null;
+    }
+
+    private static boolean parseYn(JSONObject o, String... keys) {
+        for (String k : keys) {
+            if (!o.has(k)) continue;
+            String v = String.valueOf(o.opt(k));
+            if (v == null) continue;
+            v = v.trim();
+            if (v.equalsIgnoreCase("Y") || v.equals("1") || v.equalsIgnoreCase("true")) return true;
+            if (v.equalsIgnoreCase("N") || v.equals("0") || v.equalsIgnoreCase("false")) return false;
+        }
+        return false;
+    }
+
+    private static BigDecimal parseDecimal(JSONObject o, String... keys) {
+        for (String k : keys) {
+            String raw = o.optString(k, null);
+            if (raw == null || raw.isBlank()) continue;
+            try {
+                return new BigDecimal(raw.replace(",", "").trim());
+            } catch (Exception e) {
+                log.warn("⚠️ 금액 파싱 실패 [{}]: {}", k, raw);
+            }
+        }
+        return BigDecimal.ZERO;
+    }
+
+    private static LocalDate parseDate(String yyyymmdd) {
+        if (yyyymmdd == null || yyyymmdd.isBlank()) return null;
         try {
-            String raw = obj.optString(key, "0").replace(",", "").trim();
-            return raw.isEmpty() ? BigDecimal.ZERO : new BigDecimal(raw);
+            return LocalDate.parse(yyyymmdd.replaceAll("[^0-9]", ""), DateTimeFormatter.BASIC_ISO_DATE);
         } catch (Exception e) {
-            log.warn("⚠️ 금액 파싱 실패 [{}]: {}", key, obj.optString(key));
-            return BigDecimal.ZERO;
+            log.warn("⚠️ 날짜 파싱 실패(yyyyMMdd): {}", yyyymmdd);
+            return null;
         }
     }
 
+    private static LocalDateTime parseDateTime(String yyyymmddhhmmss) {
+        if (yyyymmddhhmmss == null || yyyymmddhhmmss.isBlank()) return null;
+        String s = yyyymmddhhmmss.replaceAll("[^0-9]", ""); // 20250101T120000 → 20250101120000
+        try {
+            if (s.length() == 8) s += "000000";       // yyyyMMdd → +000000
+            else if (s.length() == 10) s += "0000";   // yyyyMMddHH → +mmss
+            else if (s.length() == 12) s += "00";     // yyyyMMddHHmm → +ss
+            else if (s.length() > 14) s = s.substring(0, 14);
+            return LocalDateTime.parse(s, DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        } catch (Exception e) {
+            log.warn("⚠️ 일시 파싱 실패(yyyyMMddHHmmss): {}", yyyymmddhhmmss);
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/scoula/nhapi/service/NhAccountServiceImpl.java
+++ b/src/main/java/org/scoula/nhapi/service/NhAccountServiceImpl.java
@@ -11,9 +11,9 @@ import org.scoula.nhapi.exception.NHApiException;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -27,29 +27,25 @@ public class NhAccountServiceImpl implements NhAccountService {
         dto.validate();
 
         JSONObject res = nhApiClient.callOpenFinAccount(dto.getAccountNumber(), dto.getBirthday());
-        log.info("🔍 핀어카운트 발급 응답: {}", res.toString());
+        log.info("🔍 핀어카운트 발급 응답: {}", res);
 
         String rpcd = res.getJSONObject("Header").getString("Rpcd");
         if ("A0013".equals(rpcd)) throw new NHApiException("이미 등록된 핀어카운트입니다.");
         if (!"00000".equals(rpcd)) throw new NHApiException("핀어카운트 발급 실패: " + rpcd);
 
-        String rgno = res.optString("Rgno");
+        String rgno = res.optString("Rgno", null);
         if (rgno == null) throw new NHApiException("Rgno가 응답에 없습니다.");
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             JSONObject checkRes = nhApiClient.callCheckFinAccount(rgno, dto.getBirthday());
-            log.info("🔁 [{}] 핀어카운트 확인 응답: {}", attempt, checkRes.toString());
+            log.info("🔁 [{}] 핀어카운트 확인 응답: {}", attempt, checkRes);
 
             if ("00000".equals(checkRes.getJSONObject("Header").getString("Rpcd"))) {
-                String finAcno = checkRes.optString("FinAcno");
+                String finAcno = checkRes.optString("FinAcno", null);
                 if (finAcno != null) return finAcno;
             }
 
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
+            try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
         }
 
         throw new NHApiException("핀어카운트 확인 실패 (FinAcno 누락)");
@@ -59,57 +55,174 @@ public class NhAccountServiceImpl implements NhAccountService {
     public BigDecimal callInquireBalance(String finAcno) {
         JSONObject res = nhApiClient.callInquireBalance(finAcno);
         String rpcd = res.getJSONObject("Header").getString("Rpcd");
-
         if (!"00000".equals(rpcd)) throw new NHApiException("잔액 조회 실패: " + rpcd);
         return new BigDecimal(res.getString("Ldbl"));
     }
 
     @Override
-    public List<NhAccountTransactionResponseDto> callTransactionList(Long userId, Long accountId, String finAcno, String from, String to) {
+    public List<NhAccountTransactionResponseDto> callTransactionList(
+            Long userId, Long accountId, String finAcno, String from, String to
+    ) {
         JSONObject res = nhApiClient.callTransactionList(finAcno, from, to);
         String rpcd = res.getJSONObject("Header").getString("Rpcd");
 
         if ("A0090".equals(rpcd)) {
-            log.info("✅ 거래내역 없음, 더미 데이터 반환 (핀어카운트: {})", finAcno);
-            return createDummyTransactions(userId, accountId);
+            log.info("✅ 거래내역 없음 → 더미 생성 (finAcno: {}, 기간: {}~{})", finAcno, from, to);
+            return createDummyTransactions(userId, accountId, from, to);
         }
-        if (!"00000".equals(rpcd)) throw new NHApiException("거래내역 조회 실패");
+        if (!"00000".equals(rpcd)) {
+            throw new NHApiException("거래내역 조회 실패: " + rpcd);
+        }
 
-        JSONArray arr = res.getJSONArray("Rec");
+        JSONArray arr = res.optJSONArray("Rec");
         List<NhAccountTransactionResponseDto> list = new ArrayList<>();
-        for (int i = 0; i < arr.length(); i++) {
-            list.add(NhAccountTransactionResponseDto.from(arr.getJSONObject(i)));
+        if (arr != null) {
+            for (int i = 0; i < arr.length(); i++) {
+                // DTO 오버로드 버전이 있으면 from(obj, userId, accountId) 쓰세요.
+                NhAccountTransactionResponseDto dto = NhAccountTransactionResponseDto.from(arr.getJSONObject(i));
+                dto.setUserId(userId);
+                dto.setAccountId(accountId);
+                list.add(dto);
+            }
         }
 
-        return list.isEmpty() ? createDummyTransactions(userId, accountId) : list;
+        if (list.isEmpty()) {
+            log.info("ℹ️ NH 응답은 성공이지만 기록 0건 → 더미 생성 (finAcno: {}, 기간: {}~{})", finAcno, from, to);
+            return createDummyTransactions(userId, accountId, from, to);
+        }
+        return list;
     }
 
-    private List<NhAccountTransactionResponseDto> createDummyTransactions(Long userId, Long accountId) {
-        List<NhAccountTransactionResponseDto> dummyList = new ArrayList<>();
-        LocalDateTime base = LocalDateTime.of(2025, 4, 1, 9, 0);
-        BigDecimal balance = BigDecimal.valueOf(1000000);
+    /**
+     * 고급 더미 생성기
+     * - 기간(from~to, yyyyMMdd) 엄수
+     * - 유저ID+계좌ID 기반 시드 → 계좌가 달라도 일관/독립 생성
+     * - 월급/고정비/일상소비 패턴 섞기
+     * - 금액/가게명/메모 다양화
+     * - tuNo: (accountId, 날짜, 인덱스) 기반 결정적 키 → 중복 방지
+     */
+    private List<NhAccountTransactionResponseDto> createDummyTransactions(Long userId, Long accountId, String from, String to) {
+        LocalDate start = parseYYYYMMDD(from, LocalDate.now().minusMonths(3));
+        LocalDate end   = parseYYYYMMDD(to,   LocalDate.now());
 
-        for (int i = 0; i < 50; i++) {
-            boolean isIncome = i % 5 == 0;
-            BigDecimal amount = isIncome ? BigDecimal.valueOf(200000 + i * 1000) : BigDecimal.valueOf(10000 + i * 300);
-            balance = isIncome ? balance.add(amount) : balance.subtract(amount);
+        // 시드: 유저+계좌 고정 (계좌마다 다르고, 재호출해도 동일 패턴)
+        long seed = Objects.hash(userId, accountId, start, end);
+        Random rnd = new Random(seed);
 
-            dummyList.add(NhAccountTransactionResponseDto.builder()
-                    .userId(userId)
-                    .accountId(accountId)
-                    .date(base.plusDays(i))
-                    .type(isIncome ? "INCOME" : "EXPENSE")
-                    .amount(amount)
-                    .balance(balance)
-                    .place(isIncome ? "입금처" : "지출처")
-                    .tuNo(100000L + i)
-                    .isCancelled(false)
-                    .memo(isIncome ? "월급" : null)
-                    .category(null)
-                    .analysis(null)
-                    .build());
+        // 초기 잔액도 시드 기반으로 약간씩 다르게
+        BigDecimal balance = BigDecimal.valueOf(700_000 + rnd.nextInt(600_000));
+
+        // 레퍼런스 테이블
+        List<String> shops = List.of("스타벅스", "이마트24", "GS25", "파리바게뜨", "배민", "쿠팡", "요기요", "다이소", "교보문고", "롯데마트");
+        List<String> memos = List.of("점심", "출근 커피", "택시", "휴지/생필품", "저녁 배달", "간식", "주말 장보기", "선물", "구독료", "쿠폰사용");
+
+        // 월급/고정비 설정
+        int payday = 25;                       // 월급일
+        BigDecimal salary = BigDecimal.valueOf(2_000_000 + rnd.nextInt(600_000));
+        Map<Integer, BigDecimal> fixedBills = Map.of(
+                2, BigDecimal.valueOf(49_000),    // 통신비
+                8, BigDecimal.valueOf(12_900),    // 넷플릭스(예시)
+                15, BigDecimal.valueOf(90_000)    // 관리비
+        );
+
+        List<NhAccountTransactionResponseDto> out = new ArrayList<>();
+        for (LocalDate d = start; !d.isAfter(end); d = d.plusDays(1)) {
+            // 1) 월급 (payday, 주말이면 전 영업일로 조정)
+            LocalDate salaryDate = adjustToWeekday(d.withDayOfMonth(Math.min(payday, d.lengthOfMonth())));
+            if (d.equals(salaryDate)) {
+                balance = balance.add(salary);
+                out.add(buildDto(userId, accountId, d.atTime(9, rnd.nextInt(20)), true,
+                        salary, balance, "급여", "월급",
+                        makeTuNo(accountId, d, 0)));
+            }
+
+            // 2) 고정비
+            for (Map.Entry<Integer, BigDecimal> bill : fixedBills.entrySet()) {
+                if (d.getDayOfMonth() == bill.getKey()) {
+                    BigDecimal amt = bill.getValue();
+                    balance = balance.subtract(amt);
+                    String place = switch (bill.getKey()) {
+                        case 2 -> "KT 통신요금";
+                        case 8 -> "넷플릭스 구독";
+                        case 15 -> "아파트 관리비";
+                        default -> "고정비";
+                    };
+                    out.add(buildDto(userId, accountId, d.atTime(8, rnd.nextInt(20)), false,
+                            amt, balance, place, "자동이체",
+                            makeTuNo(accountId, d, bill.getKey())));
+                }
+            }
+
+            // 3) 일상 소비 (평균 0~2건/일)
+            int dailyCnt = rnd.nextInt(3); // 0,1,2개
+            for (int i = 0; i < dailyCnt; i++) {
+                boolean incomeChance = rnd.nextInt(20) == 0; // 가끔 환불/입금
+                boolean isIncome = incomeChance;
+
+                BigDecimal amt = isIncome
+                        ? BigDecimal.valueOf(10_000 + rnd.nextInt(40_000))
+                        : BigDecimal.valueOf(3_000 + rnd.nextInt(70_000));
+
+                balance = isIncome ? balance.add(amt) : balance.subtract(amt);
+
+                String place = isIncome ? "이체입금" : shops.get(rnd.nextInt(shops.size()));
+                String memo  = memos.get(rnd.nextInt(memos.size()));
+
+                out.add(buildDto(userId, accountId,
+                        d.atTime(10 + rnd.nextInt(10), rnd.nextInt(60)),
+                        isIncome, amt, balance, place, memo,
+                        makeTuNo(accountId, d, 100 + i)));
+            }
         }
 
-        return dummyList;
+        // 기간 내에서 랜덤이지만 재현 가능한 순서 보장
+        out.sort(Comparator.comparing(NhAccountTransactionResponseDto::getDate));
+        return out;
+    }
+
+    private NhAccountTransactionResponseDto buildDto(
+            Long userId, Long accountId, LocalDateTime when, boolean income,
+            BigDecimal amount, BigDecimal balance, String place, String memo, long tuNo
+    ) {
+        return NhAccountTransactionResponseDto.builder()
+                .userId(userId)
+                .accountId(accountId)
+                .date(when)
+                .type(income ? "INCOME" : "EXPENSE")
+                .amount(amount)
+                .balance(balance)
+                .place(place)
+                .isCancelled(false)
+                .tuNo(tuNo)
+                .memo(memo)
+                .category(null)
+                .analysis(null)
+                .build();
+    }
+
+    private static LocalDate adjustToWeekday(LocalDate date) {
+        DayOfWeek dow = date.getDayOfWeek();
+        if (dow == DayOfWeek.SATURDAY) return date.minusDays(1);
+        if (dow == DayOfWeek.SUNDAY)   return date.minusDays(2);
+        return date;
+    }
+
+    private static LocalDate parseYYYYMMDD(String yyyymmdd, LocalDate fallback) {
+        try {
+            return LocalDate.parse(yyyymmdd, DateTimeFormatter.BASIC_ISO_DATE);
+        } catch (Exception e) {
+            return fallback;
+        }
+    }
+
+    private static long makeTuNo(Long accountId, LocalDate date, int index) {
+        // 계좌 분리 + 날짜 + 인덱스 → 결정적 키 (증분 동기화/중복체크에 안전)
+        long a = (accountId == null) ? 0L : accountId;
+        long d = Long.parseLong(date.format(DateTimeFormatter.BASIC_ISO_DATE));
+        long h = 1125899906842597L;
+        h = 31*h + a;
+        h = 31*h + d;
+        h = 31*h + index;
+        return Math.abs(h);
     }
 }

--- a/src/main/java/org/scoula/transactions/domain/CardTransaction.java
+++ b/src/main/java/org/scoula/transactions/domain/CardTransaction.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.scoula.nhapi.dto.NhCardTransactionResponseDto;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -19,7 +20,7 @@ public class CardTransaction {
     private String authNumber;
     private String salesType;
     private LocalDateTime approvedAt;
-    private String paymentDate;
+    private LocalDate paymentDate;
     private BigDecimal amount;
     private Boolean isCancelled;
     private BigDecimal cancelAmount;
@@ -37,12 +38,12 @@ public class CardTransaction {
         this.cardId = cardId;
         this.authNumber = dto.getAuthNumber();
         this.salesType = dto.getSalesType();
-        this.approvedAt = parseDateTime(dto.getApprovedAt());
-        this.paymentDate = dto.getPaymentDate(); // 문자열 그대로 저장
+        this.approvedAt = dto.getApprovedAt();
+        this.paymentDate = dto.getPaymentDate();  // 문자열 그대로 저장
         this.amount = dto.getAmount();
         this.isCancelled = dto.isCancelled();
         this.cancelAmount = dto.getCancelAmount();
-        this.cancelledAt = parseDateTime(dto.getCancelledAt());
+        this.cancelledAt = dto.getCancelledAt();
         this.merchantName = dto.getMerchantName();
         this.tpbcd = dto.getTpbcd();
         this.tpbcdNm = dto.getTpbcdNm();

--- a/src/main/java/org/scoula/transactions/mapper/AccountTransactionMapper.java
+++ b/src/main/java/org/scoula/transactions/mapper/AccountTransactionMapper.java
@@ -17,8 +17,11 @@ public interface AccountTransactionMapper {
                                                      @Param("from") String from,
                                                      @Param("to") String to);
 
-    boolean existsByUserIdAndTuNo(@Param("userId") Long userId,
-                                  @Param("tuNo") Long tuNo);
+    boolean existsByUserIdAndAccountIdAndTuNo(
+            @Param("userId") Long userId,
+            @Param("accountId") Long accountId,
+            @Param("tuNo") Long tuNo
+    );
 
     LocalDateTime findLastTransactionDate(@Param("accountId") Long accountId);
 }

--- a/src/main/java/org/scoula/transactions/mapper/CardTransactionMapper.java
+++ b/src/main/java/org/scoula/transactions/mapper/CardTransactionMapper.java
@@ -16,10 +16,11 @@ public interface CardTransactionMapper {
                                                @Param("to") String to);
     void insert(CardTransaction tx);
     void insertCardTransactions(List<CardTransaction> list);
-    boolean existsByUserIdAndKey(
+    boolean existsByUserIdAndCardIdAndKey(
             @Param("userId") Long userId,
+            @Param("cardId") Long cardId,
             @Param("authNumber") String authNumber,
-            @Param("approvedAt") String approvedAt
+            @Param("approvedAt") java.time.LocalDateTime approvedAt
     );
     LocalDateTime findLastTransactionDate(Long cardId);
     BigDecimal sumMonthlySpending(@Param("userId") Long userId,

--- a/src/main/resources/org/scoula/transactions/mapper/AccountTransactionMapper.xml
+++ b/src/main/resources/org/scoula/transactions/mapper/AccountTransactionMapper.xml
@@ -28,10 +28,11 @@
     </insert>
 
 
-    <select id="existsByUserIdAndTuNo" resultType="boolean">
-        SELECT COUNT(1) > 0
+    <select id="existsByUserIdAndAccountIdAndTuNo" resultType="boolean">
+        SELECT COUNT(1)
         FROM account_transaction
         WHERE user_id = #{userId}
+          AND account_id = #{accountId}
           AND tu_no = #{tuNo}
     </select>
 

--- a/src/main/resources/org/scoula/transactions/mapper/CardTransactionMapper.xml
+++ b/src/main/resources/org/scoula/transactions/mapper/CardTransactionMapper.xml
@@ -18,19 +18,28 @@
         ORDER BY approved_at DESC
     </select>
 
-    <insert id="insert" parameterType="org.scoula.transactions.domain.CardTransaction"
-            useGeneratedKeys="true" keyProperty="id">
+    <!-- CardTransactionMapper.xml -->
+    <insert id="insert"
+            parameterType="org.scoula.transactions.domain.CardTransaction"
+            useGeneratedKeys="true"
+            keyProperty="id">
         INSERT INTO card_transaction (
-            user_id, card_id, auth_number, sales_type, approved_at, payment_date,
-            amount, is_cancelled, cancel_amount, cancelled_at, merchant_name,
-            tpbcd, tpbcd_nm, installment_month, currency, foreign_amount, created_at
-        )
-        VALUES (
-                   #{userId}, #{cardId}, #{authNumber}, #{salesType}, #{approvedAt}, #{paymentDate},
-                   #{amount}, #{isCancelled}, #{cancelAmount}, #{cancelledAt}, #{merchantName},
-                   #{tpbcd}, #{tpbcdNm}, #{installmentMonth}, #{currency}, #{foreignAmount}, #{createdAt}
-               )
+            user_id, card_id, auth_number, sales_type,
+            approved_at, payment_date,
+            amount, is_cancelled, cancel_amount, cancelled_at,
+            merchant_name, tpbcd, tpbcd_nm, installment_month, currency, foreign_amount, created_at
+        ) VALUES (
+                     #{userId}, #{cardId}, #{authNumber}, #{salesType},
+                     #{approvedAt, jdbcType=TIMESTAMP, typeHandler=org.apache.ibatis.type.LocalDateTimeTypeHandler},
+                     #{paymentDate, jdbcType=DATE, typeHandler=org.apache.ibatis.type.LocalDateTypeHandler},
+                     #{amount}, #{isCancelled}, #{cancelAmount},
+                     #{cancelledAt, jdbcType=TIMESTAMP, typeHandler=org.apache.ibatis.type.LocalDateTimeTypeHandler},
+                     #{merchantName}, #{tpbcd}, #{tpbcdNm}, #{installmentMonth}, #{currency}, #{foreignAmount},
+                     NOW()
+                 )
     </insert>
+
+
 
 
 
@@ -51,19 +60,20 @@
         </foreach>
     </insert>
 
-    <select id="existsByUserIdAndKey" resultType="boolean">
-        SELECT EXISTS(
-            SELECT 1 FROM card_transaction
-            WHERE user_id = #{userId}
-              AND auth_number = #{authNumber}
-              AND approved_at = #{approvedAt}
-        )
+    <!-- 중복 체크 -->
+    <select id="existsByUserIdAndCardIdAndKey" resultType="boolean">
+        SELECT COUNT(1)
+        FROM card_transaction
+        WHERE user_id   = #{userId}
+        AND card_id   = #{cardId}
+        AND auth_number = #{authNumber}
+        AND approved_at = #{approvedAt, jdbcType=TIMESTAMP,
+        typeHandler=org.apache.ibatis.type.LocalDateTimeTypeHandler}  <!-- ✅ -->
     </select>
 
+    <!-- 마지막 승인일 -->
     <select id="findLastTransactionDate" resultType="java.time.LocalDateTime">
-        SELECT MAX(approved_at)
-        FROM card_transaction
-        WHERE card_id = #{cardId}
+        SELECT MAX(approved_at) FROM card_transaction WHERE card_id = #{cardId}
     </select>
 
     <select id="sumMonthlySpending" resultType="java.math.BigDecimal">


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약
- 계좌/카드 **동기화 안정화**: 증분 시작일을 “마지막 거래일 + 1일”로 통일하고 중복키 강化
- NH API 응답 없을 때 **더미 데이터 고도화**(기간 맞춤, 계좌/유저별 시드, 현실적 패턴)
- 카드 승인내역 파싱/저장 **타입 정합성** 확보(LocalDateTime/LocalDate)
- **approved_at NULL** / **ledger.source_id NULL** 발생 원인 제거  
  (useGeneratedKeys로 거래 PK 주입, ledger.source_id=거래PK)

## 📖 작업 내용
### 1) Account(계좌) 동기화
- `AccountTransactionServiceImpl`
  - 기본 동기화는 **증분 모드**로 수행 (`getNextStartDate=마지막+1일`, 없으면 3개월 전)
  - 중복 체크 키를 `userId + accountId + tuNo`로 강화
  - 수입 거래만 ledger 반영(카테고리 10 “이체”), from~to 로그 출력

- `NhAccountServiceImpl`
  - NH 응답 `A0090` 혹은 빈 Rec 시 **기간 기반 더미 생성**(`createDummyTransactions`)
  - 더미는 from~to(yyyyMMdd) **엄수**, 계좌/유저 기반 시드로 **재현성 보장**
  - 급여/고정비/일상소비 패턴, 금액/가맹점/메모 다양화
  - tuNo를 `(accountId, 날짜, 인덱스)` 조합의 **결정적 키**로 생성

- `NhAccountTransactionResponseDto`
  - `parseDateTime` 보강(HHmm/HHmmss 변형 대응)
  - 안정적 tuNo 해시(`generateTuNo`), `from(obj, userId, accountId)` 오버로드
  - `isIncome()` 제공

### 2) Card(카드) 동기화
- `NhCardParser` / `NhCardTransactionResponseDto`
  - 응답 키 변종(`AthzDtm/AprvDtm/ApprovedDateTime` 등) **광범위 대응**
  - `approvedAt/cancelledAt` → `LocalDateTime`, `paymentDate` → `LocalDate`로 **타입 확정**
  - 금액/YN 파싱 유틸로 안정성 향상

- `CardTransaction` (도메인)
  - DTO 값을 **타입 그대로 매핑**  
    (문자열 재파싱 제거: `approvedAt/ cancelledAt`은 `LocalDateTime`, `paymentDate`는 `LocalDate`)

- `CardTransactionServiceImpl`
  - 증분 시작일 계산(`getNextStartDate`)
  - **approvedAt null 가드**(로그 후 skip)
  - 중복 체크 키를 `userId + cardId + authNumber + approvedAt(LocalDateTime)`로 강화
  - `mapper.insert(tx)` 후 **useGeneratedKeys로 tx.id 확보**
  - `ledger.source_id = tx.id`로 설정(요구사항: **원천=거래PK**)
  - 취소건은 ledger 미반영

### 3) MyBatis Mapper
- `CardTransactionMapper.xml`
  - `insert`에 `useGeneratedKeys="true" keyProperty="id"` 설정 → **PK 자동 주입**
  - `TIMESTAMP/DATE` 컬럼에 **JSR-310 타입핸들러** 명시
  - `existsByUserIdAndCardIdAndKey`에서 `approved_at`을 `LocalDateTime`으로 비교
  - `findLastTransactionDate` → `LocalDateTime` 반환
  - (배치 insert 템플릿에도 타입핸들러 주석 제공)

> 참고: 계좌 쪽도 동일한 패턴으로 적용(중복키 강화, 기간 계산, 더미/실데이터 처리 일관화)

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수 (conventional commits)
- [x] 로컬 환경에서 동작 확인 완료 (approved_at/source_id NULL 이슈 재현 후 해결)
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## 🔗 관련 이슈

closes #187 
