### PR TITLE
feat: 간편비밀번호 기능 추가

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -8,7 +8,7 @@ CREATE TABLE `user` (
                         `id` BIGINT NOT NULL AUTO_INCREMENT,
                         `email` VARCHAR(255) NOT NULL,
                         `password` VARCHAR(255) NOT NULL,
-                        `auth_pw` VARBINARY(255) NULL,
+                        `auth_pw` VARCHAR(255) NULL,
                         `user_name` VARCHAR(255) NULL,
                         `phone_num` VARCHAR(255) NULL,
                         `birthday` DATE NULL,

--- a/src/main/java/org/scoula/security/account/domain/CustomUserDetails.java
+++ b/src/main/java/org/scoula/security/account/domain/CustomUserDetails.java
@@ -62,4 +62,6 @@ public class CustomUserDetails implements UserDetails {
         return user.getUserName();
     }
 
+    public String getPin(){return user.getAuthPw();}
+
 }

--- a/src/main/java/org/scoula/user/controller/AuthController.java
+++ b/src/main/java/org/scoula/user/controller/AuthController.java
@@ -2,14 +2,18 @@ package org.scoula.user.controller;
 
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.scoula.common.redis.RedisService;
 import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.security.account.domain.CustomUserDetails;
 import org.scoula.security.account.dto.UserLoginRequestDTO;
 import org.scoula.security.util.CookieUtil;
+import org.scoula.user.dto.PinRequestDTO;
 import org.scoula.user.dto.TokenResponseDTO;
 import org.scoula.user.service.UserService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -97,4 +101,14 @@ public class AuthController {
     public void swaggerLoginForDocs(@RequestBody UserLoginRequestDTO request) {
         throw new IllegalStateException("swagger 상 필터호출을 위한 엔드포인트입니다.");
     }
+
+
+    //pin 로그인
+    @ApiOperation(value = "간편비밀번호 로그인", notes = "오픈뱅킹")
+    @PostMapping("/pin/login")
+    public CommonResponseDTO<Void> pinLogin(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody PinRequestDTO pinRequestDTO) {
+        userService.pinLogin(userDetails.getUsername(), userDetails.getUserId(), pinRequestDTO);
+        return CommonResponseDTO.success("간편 비밀번호 로그인이 성공했습니다.");
+    }
+
 }

--- a/src/main/java/org/scoula/user/controller/UserController.java
+++ b/src/main/java/org/scoula/user/controller/UserController.java
@@ -1,13 +1,14 @@
 package org.scoula.user.controller;
 
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.security.account.domain.CustomUserDetails;
 import org.scoula.user.domain.User;
-import org.scoula.user.dto.UserJoinRequestDTO;
-import org.scoula.user.dto.UserEmailRequestDTO;
-import org.scoula.user.dto.UserResponseDTO;
+import org.scoula.user.dto.*;
 import org.scoula.user.service.UserService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -49,6 +50,22 @@ public class UserController {
     public CommonResponseDTO<Void> withdrawal(@RequestHeader("Authorization") String token) {
         userService.withdrawal(token);
         return CommonResponseDTO.success("회원 탈퇴가 완료되었습니다.");
+    }
+
+    //핀번호 세팅
+    @ApiOperation(value = "간편비밀번호 설정 ", notes = "간편비밀번호를 초기 설정합니다.")
+    @PostMapping("/pin")
+    public CommonResponseDTO<Void> setPin(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody PinRequestDTO pinRequestDTO) {
+        userService.setPin(userDetails.getUserId(),pinRequestDTO);
+        return CommonResponseDTO.success("간편비밀번호 설정이 완료되었습니다.");
+    }
+
+    //핀번호 리셋
+    @ApiOperation(value = "간편비밀번호 재설정 ", notes = "간편비밀번호를 다시 설정합니다.")
+    @PutMapping("/pin/reset")
+    public CommonResponseDTO<Void> resetLogin(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody PinRequestDTO pinRequestDTO) {
+        userService.resetPin(userDetails.getUserId(),pinRequestDTO);
+        return CommonResponseDTO.success("간편비밀번호 재설정이 완료되었습니다.");
     }
 
 }

--- a/src/main/java/org/scoula/user/domain/User.java
+++ b/src/main/java/org/scoula/user/domain/User.java
@@ -18,4 +18,5 @@ public class User {
     private LocalDateTime lastPwChangeAt;
     private Boolean isVerified;
     private Boolean isActive;
+    private String authPw;
 }

--- a/src/main/java/org/scoula/user/dto/PinRequestDTO.java
+++ b/src/main/java/org/scoula/user/dto/PinRequestDTO.java
@@ -1,0 +1,14 @@
+package org.scoula.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PinRequestDTO {
+    int pin;
+}

--- a/src/main/java/org/scoula/user/exception/auth/InvalidPinException.java
+++ b/src/main/java/org/scoula/user/exception/auth/InvalidPinException.java
@@ -1,0 +1,7 @@
+package org.scoula.user.exception.auth;
+
+import org.scoula.common.exception.BaseException;
+
+public class InvalidPinException extends BaseException {
+    public InvalidPinException() {super("간편비밀번호가 올바르지 않습니다.", 401);}
+}

--- a/src/main/java/org/scoula/user/mapper/UserMapper.java
+++ b/src/main/java/org/scoula/user/mapper/UserMapper.java
@@ -14,4 +14,7 @@ public interface UserMapper {
     void updatePassword(User user); // 비밀번호 재발급
     void insertUserChallengeSummary(@Param("userId") Long userId);
     void updateIsActive(@Param("id") Long id);
+
+    void updatePin(User user);
+    String getPin(@Param("userId") Long userId);
 }

--- a/src/main/java/org/scoula/user/service/UserService.java
+++ b/src/main/java/org/scoula/user/service/UserService.java
@@ -14,4 +14,7 @@ public interface UserService {
     void logout(String token);
     void withdrawal(String token);
     void checkAndLevelUp(Long userId);
+    void setPin(Long userId, PinRequestDTO pinRequestDTO);
+    void resetPin(Long userId, PinRequestDTO pinRequestDTO);
+    void pinLogin(String email, Long userId, PinRequestDTO pinRequestDTO);
 }

--- a/src/main/java/org/scoula/user/service/UserServiceImpl.java
+++ b/src/main/java/org/scoula/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package org.scoula.user.service;
 
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.scoula.agree.mapper.AgreeMapper;
 import org.scoula.avatar.mapper.AvatarMapper;
@@ -8,10 +9,8 @@ import org.scoula.coin.mapper.CoinMapper;
 import org.scoula.common.redis.RedisService;
 import org.scoula.user.domain.User;
 import org.scoula.user.domain.UserStatus;
-import org.scoula.user.dto.TokenResponseDTO;
-import org.scoula.user.dto.UserJoinRequestDTO;
+import org.scoula.user.dto.*;
 import org.scoula.security.account.dto.UserLoginRequestDTO;
-import org.scoula.user.dto.UserResponseDTO;
 import org.scoula.user.enums.UserLevel;
 import org.scoula.user.exception.auth.*;
 import org.scoula.user.exception.signup.DuplicateEmailException;
@@ -27,6 +26,7 @@ import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -231,5 +231,50 @@ public class UserServiceImpl implements UserService {
         } else {
             log.info("포인트는 증가했으나, 승급에는 실패했습니다.");
         }
+    }
+
+    @ApiOperation(value = "간편비밀번호 설정 ", notes = "간편비밀번호를 초기 설정합니다.")
+    @Override
+    public void setPin(Long userId, PinRequestDTO req) {
+
+        log.info("🔒 간편비밀번호 설정 시도: {}", req.getPin());
+
+        //간편비밀번호 문자열로 형변환하여 암호화
+        String encodedPin= encoder.encode(String.valueOf(req.getPin()));
+
+        //유저테이블에 저장
+        User u=new User();
+        u.setId(userId);
+        u.setAuthPw(encodedPin);
+        userMapper.updatePin(u);
+    }
+
+    @ApiOperation(value = "간편비밀번호 일치여부 확인.", notes = "사용자가 입력한 간편비밀번호와 실제 간편비밀번호가 일치하는지 조회합니다.")
+    @Override
+    public void pinLogin(String email, Long userId, PinRequestDTO req) {
+
+        //유저정보 조회
+        User u = userMapper.findByEmail(email);
+
+        //유저정보의 pin과, 유저가 입력한 pin의 일치여부 판단
+        if (!encoder.matches(String.valueOf(req.getPin()), u.getAuthPw())) {
+            throw new InvalidPinException();
+        }
+    }
+
+    @ApiOperation(value = "간편비밀번호 재설정 ", notes = "간편비밀번호를 재설정합니다.")
+    @Override
+    public void resetPin(Long userId, PinRequestDTO req) {
+
+        log.info("🔒 간편비밀번호 재설정 시도: {}", req.getPin());
+
+        //간편비밀번호 암호화
+        String encodedPin= encoder.encode(String.valueOf(req.getPin()));
+
+        //암호화된 간편비밀번호 저장
+        User u=new User();
+        u.setId(userId);
+        u.setAuthPw(encodedPin);
+        userMapper.updatePin(u);
     }
 }

--- a/src/main/resources/org/scoula/user/mapper/UserMapper.xml
+++ b/src/main/resources/org/scoula/user/mapper/UserMapper.xml
@@ -22,6 +22,7 @@
         SELECT nickname FROM user_status WHERE id = #{id}
     </select>
 
+
     <update id="updatePassword" parameterType="org.scoula.user.domain.User">
         UPDATE user
         SET password = #{password},
@@ -39,4 +40,13 @@
         SET is_active = false
         WHERE id = #{id}
     </update>
+
+    <update id="updatePin" parameterType="org.scoula.user.domain.User">
+        UPDATE user SET auth_pw = #{authPw} WHERE id=#{id}
+    </update>
+
+    <select id="getPin" resultType="String">
+        SELECT auth_pw FROM user WHERE id=#{userId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

간편비밀번호 기능추가

## 📖 작업 내용 

초기 세팅에, 숫자로 이뤄진 간편비밀번호를 단방향 암호화(Bcrypt)시켜 저장
이후 로그인은 해시값 비교로 이뤄짐
이외에도 jwt토큰 적용 상태에서 비밀번호 재설정 가능

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

closes #174
