### PR TITLE
Fix/#191 challenge nickname deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,16 @@ FROM tomcat:9.0-jdk17
 
 ENV TZ=Asia/Seoul
 
+# Python3/pip 설치
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip && \
+    ln -sf /usr/bin/python3 /usr/local/bin/python && \
+    rm -rf /var/lib/apt/lists/*
+
+# requirements 설치
+COPY src/main/resources/python/requirements.txt /opt/app/requirements.txt
+RUN pip install --no-cache-dir -r /opt/app/requirements.txt
+
 # 2️⃣ 기존 webapps 내용 제거 (기본 ROOT 등 제거)
 RUN rm -rf /usr/local/tomcat/webapps/*
 
@@ -12,7 +22,8 @@ COPY build/libs/*.war /usr/local/tomcat/webapps/ROOT.war
 # 4️⃣ WAR 파일 수동 언팩 (jar 명령어로 압축 해제)
 RUN mkdir /usr/local/tomcat/webapps/ROOT && \
     cd /usr/local/tomcat/webapps/ROOT && \
-    jar -xvf /usr/local/tomcat/webapps/ROOT.war
+    jar -xvf /usr/local/tomcat/webapps/ROOT.war && \
+    chmod -R +x /usr/local/tomcat/webapps/ROOT/WEB-INF/classes/python || true
 
 # 5️⃣ 8080 포트 개방
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # 1️⃣ Tomcat 9 기반 이미지 사용
 FROM tomcat:9.0-jdk17
 
+ENV TZ=Asia/Seoul
+
 # 2️⃣ 기존 webapps 내용 제거 (기본 ROOT 등 제거)
 RUN rm -rf /usr/local/tomcat/webapps/*
 

--- a/src/main/java/org/scoula/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/scoula/challenge/controller/ChallengeController.java
@@ -25,7 +25,7 @@ public class ChallengeController {
 
     private final ChallengeService challengeService;
 
-    // ✅ 토큰 직접 파싱 제거, @AuthenticationPrincipal 로 유저 주입
+    // 토큰 직접 파싱 제거, @AuthenticationPrincipal 로 유저 주입
     @PostMapping("/create")
     public CommonResponseDTO<ChallengeCreateResponseDTO> createChallenge(
             @RequestBody ChallengeCreateRequestDTO req,

--- a/src/main/java/org/scoula/challenge/dto/ChallengeListResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeListResponseDTO.java
@@ -1,19 +1,27 @@
 package org.scoula.challenge.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
 
 import java.time.LocalDate;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ChallengeListResponseDTO {
     private Long id;
     private String title;
+
     private ChallengeType type;
-    private String categoryName; // 추가
+    private ChallengeStatus status;   // 카드에서 상태 표시용
+    private String categoryName;
 
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate startDate;
@@ -21,9 +29,20 @@ public class ChallengeListResponseDTO {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;
 
-    private boolean isParticipating; // 나의 참여 여부
-    private Double myProgressRate;   // 개인/소그룹 챌린지일 경우
-    private int participantsCount;   // 모집중인 경우
+    // 목표/보상/인원 정보도 리스트에서 바로 쓰게 전달
+    private String goalType;          // 예: "소비"
+    private Integer goalValue;
+    private Integer maxParticipants;  // 예: GROUP=6, PERSONAL=1
+    private Integer participantsCount;
+    private Integer rewardPoint;
 
-    private Boolean isResultCheck;
+    // 참여 여부 & 진행률 & 결과확인 여부
+    // 프론트 호환을 위해 JSON 키는 기존처럼 isParticipating / isResultCheck 로 유지
+    @JsonProperty("isParticipating")
+    private Boolean participating;    // primitive X (널 안전)
+
+    private Double myProgressRate;    // null 가능 (미참여/COMMON 등)
+
+    @JsonProperty("isResultCheck")
+    private Boolean resultChecked;    // primitive X (널 안전)
 }

--- a/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
@@ -153,19 +153,18 @@ public class ChallengeServiceImpl implements ChallengeService {
         return challenges.stream()
                 .filter(challenge -> {
                     boolean isParticipating = userChallengeIds.contains(challenge.getId());
-
-                    if (participating == null) return true; // 필터 안 씀
-                    if (participating) return isParticipating; // 참여한 챌린지만
-                    else return !isParticipating;              // 참여 안 한 챌린지만
+                    if (participating == null) return true;
+                    return participating ? isParticipating : !isParticipating;
                 })
                 .map(challenge -> {
                     boolean isParticipating = userChallengeIds.contains(challenge.getId());
                     String categoryName = challengeMapper.getCategoryNameById(challenge.getCategoryId());
 
-                    // 참여한 챌린지인 경우만 결과 확인 여부 조회
                     Boolean resultChecked = false;
                     if (isParticipating) {
-                        resultChecked = Boolean.TRUE.equals(challengeMapper.isResultChecked(userId, challenge.getId()));
+                        resultChecked = Boolean.TRUE.equals(
+                                challengeMapper.isResultChecked(userId, challenge.getId())
+                        );
                     }
 
                     Double myProgress = null;
@@ -180,16 +179,22 @@ public class ChallengeServiceImpl implements ChallengeService {
                     return ChallengeListResponseDTO.builder()
                             .id(challenge.getId())
                             .title(challenge.getTitle())
-                            .categoryName(categoryName)
                             .type(challenge.getType())
+                            .status(challenge.getStatus())                   // 추가
+                            .categoryName(categoryName)
                             .startDate(challenge.getStartDate())
                             .endDate(challenge.getEndDate())
-                            .isParticipating(isParticipating)
-                            .myProgressRate(myProgress)
+                            .goalType(challenge.getGoalType())               // 추가
+                            .goalValue(challenge.getGoalValue())             // 추가
+                            .maxParticipants(challenge.getMaxParticipants())  // 추가
                             .participantsCount(challenge.getParticipantCount())
-                            .isResultCheck(resultChecked)
+                            .rewardPoint(challenge.getRewardPoint())         // 추가
+                            .participating(isParticipating)                  // Boolean
+                            .myProgressRate(myProgress)
+                            .resultChecked(resultChecked)                    // Boolean
                             .build();
-                }).collect(Collectors.toList());
+                })
+                .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/org/scoula/finance/util/PythonExecutorUtil.java
+++ b/src/main/java/org/scoula/finance/util/PythonExecutorUtil.java
@@ -1,42 +1,90 @@
 package org.scoula.finance.util;
 
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 @Component
 public class PythonExecutorUtil {
 
-    public static void runPythonScript(String scriptPath, String... args) throws IOException, InterruptedException {
+    // ---------- 요청별 작업폴더 ----------
+    public static final class JobWorkspace {
+        public final File root;  // ex) .../WEB-INF/classes/python/jobs/<uuid>
 
-        ProcessBuilder builder = new ProcessBuilder();
-        builder.command(buildCommand(scriptPath, args));
-        builder.redirectErrorStream(true);
+        private JobWorkspace(File root) { this.root = root; }
 
-        Process process = builder.start();
+        public File resolve(String relative) { return new File(root, relative); }
 
-        try(BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-            String line;
-            while((line = reader.readLine()) != null) {
-                System.out.println("[Python} " + line);
-            }
+        public void mkdirsFor(File f) {
+            File p = f.getParentFile();
+            if (p != null) p.mkdirs();
         }
 
-        int exitCode = process.waitFor();
-        if(exitCode != 0) {
-            throw new RuntimeException("python 실행 실패 (exit code: " + exitCode + ")");
+        public void cleanupQuietly() {
+            try { deleteRecursively(root); } catch (Exception ignore) {}
         }
     }
 
-    private static List<String> buildCommand(String scriptPath, String[] args){
-        List<String> command = new ArrayList<>();
-        command.add("python");
-        command.add(scriptPath);
-        for(String arg : args){
-            command.add(arg);
+    public static JobWorkspace createJobWorkspace(File pyRoot) {
+        File jobs = new File(pyRoot, "jobs");
+        File ws = new File(jobs, UUID.randomUUID().toString());
+        ws.mkdirs();
+        return new JobWorkspace(ws);
+    }
+
+    // ---------- 실행 유틸 ----------
+    public static void runPythonScript(String scriptAbsolutePath, File workingDir, String... args)
+            throws IOException, InterruptedException {
+
+        List<String> cmd = new ArrayList<>();
+        cmd.add("python");
+        cmd.add(scriptAbsolutePath);
+        if (args != null) Collections.addAll(cmd, args);
+
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        if (workingDir != null) pb.directory(workingDir);      // ★ CWD = 작업폴더
+        pb.redirectErrorStream(true);
+
+        Process p = pb.start();
+
+        try (BufferedReader r =
+                     new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = r.readLine()) != null) System.out.println("[Python] " + line);
         }
-        return command;
+
+        int code = p.waitFor();
+        if (code != 0) throw new RuntimeException("python 실행 실패 (exit code: " + code + ")");
+    }
+
+    // WAR 언팩이면 getFile(); 아니면 임시복사 폴백
+    public static File asFileOrTemp(ClassPathResource res) throws IOException {
+        try {
+            return res.getFile();
+        } catch (Exception ignore) {
+            File tmp = File.createTempFile("res-", "-" + new File(res.getPath()).getName());
+            try (InputStream in = res.getInputStream(); OutputStream out = new FileOutputStream(tmp)) {
+                in.transferTo(out);
+            }
+            tmp.deleteOnExit();
+            return tmp;
+        }
+    }
+
+    public static File getPyRootFrom(ClassPathResource res) throws IOException {
+        File script = asFileOrTemp(res);
+        return script.getParentFile().getParentFile(); // .../python
+    }
+
+    private static void deleteRecursively(File f) {
+        if (f == null || !f.exists()) return;
+        if (f.isDirectory()) {
+            File[] children = f.listFiles();
+            if (children != null) for (File c : children) deleteRecursively(c);
+        }
+        if (!f.delete()) f.deleteOnExit();
     }
 }

--- a/src/main/java/org/scoula/user/util/NicknameGenerator.java
+++ b/src/main/java/org/scoula/user/util/NicknameGenerator.java
@@ -22,7 +22,7 @@ public class NicknameGenerator {
 
     private static final MediaType JSON = MediaType.parse("application/json");
 
-    // ✅ 1) OkHttpClient는 앱 전역에서 재사용 (스레드세이프)
+    // 1) OkHttpClient는 앱 전역에서 재사용 (스레드세이프)
     private static final OkHttpClient CLIENT = new OkHttpClient.Builder()
             .connectTimeout(Duration.ofSeconds(5))
             .readTimeout(Duration.ofSeconds(15))
@@ -35,7 +35,7 @@ public class NicknameGenerator {
 
     public String generateNickname() {
         try {
-            String prompt = "랜덤한 {동사}하는{동물 또는 캐릭터} 형태의 한국어 닉네임을 한 개만 출력해줘. 예: '코딩하는토끼'";
+            String prompt = "랜덤한 {금융 관련 동사}하는 {동물 또는 캐릭터} 형태의 한국어 닉네임을 한 개만 출력해줘. 예: '주식하는 토끼'";
 
             JSONObject requestBody = new JSONObject()
                     .put("model", "gpt-4o")  // 필요시 gpt-4o-mini

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -37,14 +37,21 @@
     </select>
 
     <select id="getUserProgress" resultType="double">
-        SELECT actual_value * 1.0 / goal_value
+        SELECT CASE
+                   WHEN c.goal_value IS NULL OR c.goal_value = 0 THEN NULL
+                   ELSE uc.actual_value * 1.0 / c.goal_value
+                   END
         FROM user_challenge uc
                  JOIN challenge c ON uc.challenge_id = c.id
         WHERE uc.user_id = #{userId} AND uc.challenge_id = #{challengeId}
     </select>
 
     <select id="getGroupAverageProgress" resultType="double">
-        SELECT AVG(actual_value * 1.0 / c.goal_value)
+        SELECT AVG(
+                       CASE WHEN c.goal_value IS NULL OR c.goal_value = 0 THEN NULL
+                            ELSE uc.actual_value * 1.0 / c.goal_value
+                           END
+               )
         FROM user_challenge uc
                  JOIN challenge c ON uc.challenge_id = c.id
         WHERE uc.challenge_id = #{challengeId}

--- a/src/main/resources/python/requirements.txt
+++ b/src/main/resources/python/requirements.txt
@@ -1,0 +1,13 @@
+# core
+numpy==1.26.4
+pandas==2.2.2
+scipy==1.11.4
+statsmodels==0.14.5
+patsy==0.5.6
+
+# io/network/html
+requests==2.32.3
+lxml==5.3.0
+
+# market
+pykrx==1.0.51


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약

* 컨테이너에서 파이썬 스크립트가 실행되지 않던 이슈 해결
* 파이썬 의존성 설치를 **Docker 이미지 빌드 시점**으로 고정(배포 시 수동 pip 불필요)
* 경로/동시성 문제를 해결하기 위해 **요청별 작업 폴더(Workspace)** 도입 및 서비스 전반 리팩터링
* 회원가입 시 **닉네임 GPT 랜덤 생성** 로직 반영
* **챌린지 리스트 조회 응답 포맷/내용** 수정

## 📖 작업 내용

### 1) Dockerfile 수정

* `tomcat:9.0-jdk17` 기반 이미지에 Python3 + pip 설치
* `requirements.txt`(경로: `src/main/resources/python/requirements.txt`)를 복사 후 `pip install -r` 수행
* `TZ=Asia/Seoul` 설정
* WAR 언팩 후 리소스 파이썬 스크립트에 실행 권한 부여
  → 결과적으로 컨테이너 내에서 `python` 명령과 필요한 패키지 사용 가능

### 2) 파이썬 실행 유틸 개선 (`PythonExecutorUtil`)

* **작업 디렉토리(CWD) 지정 지원**: 파이썬의 `./data/...` 상대경로가 원하는 위치에 생성되도록 보장
* **요청별 워크스페이스(JobWorkspace)** 추가: `jobs/<UUID>/...` 경로 내에서 입출력 수행 → 파일 경합/덮어쓰기 방지
* `ClassPathResource`가 파일이 아닐 경우를 대비한 **임시파일 폴백(asFileOrTemp)** 제공
* `getPyRootFrom(...)` 추가: `…/WEB-INF/classes/python` 루트 자동 인식
* 실행 로그/에러 처리 개선

### 3) 서비스 리팩터링 (파이썬 호출부 전면 정리)

* 공통: 각 서비스에서 `ClassPathResource("python/…")`로 스크립트 파일 확보 → `pyRoot` 계산 → **요청별 워크스페이스 생성** → 입력/출력 파일을 워크스페이스 기준으로 읽고/쓰기 → **CWD=워크스페이스**로 파이썬 실행 → 완료 후 **워크스페이스 정리**
* 수정 파일

  * `DepositServiceImpl` : 예금 추천 분석 I/O를 워크스페이스로 분리
  * `FundServiceImpl` : 펀드 효용 계산 I/O를 워크스페이스로 분리
  * `InstallmentServiceImpl` : 적금 추천 분석 I/O를 워크스페이스로 분리
  * `StockServiceImpl`

    * `updateChartData()` : 일/주가 데이터 수집 결과를 워크스페이스에서 읽어 DB 반영
    * `updateFactor(...)` : 팩터 계산 결과 저장/사용
    * `getStockReturn(...)` : 개별 종목 수익률 계산 결과 사용
    * `getStockRecommendationList(...)` : 입력 JSON(factor/stock list)도 워크스페이스에 생성하여 동시성 안전

> 효과: 로컬 톰캣/서버 톰캣/도커 컨테이너 **모두 동일한 방식**으로 동작하며, 경로/권한/동시성 문제 제거

### 4) 기능 수정

* **회원가입 닉네임 GPT 랜덤 생성** 로직 반영 (요청사항 대응)
* **챌린지 리스트 조회 응답** 포맷/필드 정리

### 5) 문서/구조

* `requirements.txt` 추가 및 고정 버전 명시
  (예: `numpy`, `pandas`, `scipy`, `statsmodels`, `patsy`, `pykrx`, `requests`, `lxml` 등)

## ✅ 체크리스트

* [x] 커밋 컨벤션 준수
* [x] 로컬 환경에서 동작 확인 완료 (레거시 스프링 + 톰캣)
* [ ] 리뷰어 n명 이상 승인 완료
* [ ] 문서화가 필요한 경우 추가했습니다. *(README에 운영/로컬 공통 실행 가이드 보강 예정)*
* [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

1. **Python 버전 고정 여부**

   * 현재는 OS 기본 Python3 사용(성능/빌드속도 유리). 정확 버전 고정이 필요하면 `python:3.13-slim`으로 venv를 만들어 **멀티스테이지**로 가져오는 방식으로 전환할까요?
2. **배치 작업 스케줄링**

   * `updateChartData`, `updateFactor` 등의 실행 주기/트리거(스케줄러 or 수동)를 정해둘까요?
3. **워크스페이스 보존 정책**

   * 현재는 성공/실패 모두 **정리(삭제)**. 이슈 분석을 위해 실패 시 **보존 옵션**을 둘까요? (예: 환경변수로 토글)
4. **보안 그룹**

   * 운영 EC2의 인바운드가 `전체/전체`로 열려 있음. 포트 최소화/제한(22, 80/443 or 8080)로 변경 진행해도 될까요?

## 🔗 관련 이슈

* closes #182  *(파이썬 실행/경로/동시성 이슈 정리 및 Docker 배포 고정)*
* closes #190  *(회원가입 닉네임 GPT 랜덤 생성 반영)*
* closes #191  *(챌린지 리스트 조회 응답 수정)*

---

**배포 노트(요약)**

* 별도 수동 `pip` 불필요. CI/CD에서 Docker 빌드시 자동 설치
* 환경변수(주식 API, OpenAI API)와 **아웃바운드 네트워크 허용**만 확인
* 실행 로그에서 `[Python]` 프리픽스로 파이썬 표준출력 확인 가능
