### PR TITLE
fix: dockerfile venv 사용방식으로 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,34 @@
-# 1️⃣ Tomcat 9 기반 이미지 사용
+# 1️⃣ Tomcat 9 기반 이미지
 FROM tomcat:9.0-jdk17
 
 ENV TZ=Asia/Seoul
 
-# Python3/pip 설치
+# 2️⃣ Python + venv 설치 (PEP668 회피)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 python3-pip && \
-    ln -sf /usr/bin/python3 /usr/local/bin/python && \
+    apt-get install -y --no-install-recommends python3 python3-pip python3-venv && \
+    python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --upgrade pip && \
+    ln -sf /opt/venv/bin/python /usr/local/bin/python && \
     rm -rf /var/lib/apt/lists/*
 
-# requirements 설치
+# venv 우선 사용
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# 3️⃣ requirements 설치 (venv 내부 pip)
 COPY src/main/resources/python/requirements.txt /opt/app/requirements.txt
 RUN pip install --no-cache-dir -r /opt/app/requirements.txt
 
-# 2️⃣ 기존 webapps 내용 제거 (기본 ROOT 등 제거)
+# 4️⃣ 기존 webapps 제거
 RUN rm -rf /usr/local/tomcat/webapps/*
 
-# 3️⃣ WAR 파일을 컨테이너로 복사
+# 5️⃣ WAR 복사
 COPY build/libs/*.war /usr/local/tomcat/webapps/ROOT.war
 
-# 4️⃣ WAR 파일 수동 언팩 (jar 명령어로 압축 해제)
+# 6️⃣ 수동 언팩 + 실행권한
 RUN mkdir /usr/local/tomcat/webapps/ROOT && \
     cd /usr/local/tomcat/webapps/ROOT && \
     jar -xvf /usr/local/tomcat/webapps/ROOT.war && \
     chmod -R +x /usr/local/tomcat/webapps/ROOT/WEB-INF/classes/python || true
 
-# 5️⃣ 8080 포트 개방
+# 7️⃣ 포트
 EXPOSE 8080
-
-# 6️⃣ Tomcat 실행 (기본 ENTRYPOINT 사용)


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

dockerfile venv 사용방식으로 수정

## 📖 작업 내용 
```
# 2️⃣ Python + venv 설치 (PEP668 회피)
RUN apt-get update && \
    apt-get install -y --no-install-recommends python3 python3-pip python3-venv && \
    python3 -m venv /opt/venv && \
    /opt/venv/bin/pip install --upgrade pip && \
    ln -sf /opt/venv/bin/python /usr/local/bin/python && \
    rm -rf /var/lib/apt/lists/*

# venv 우선 사용
ENV PATH="/opt/venv/bin:${PATH}"

```

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- 관련된 이슈 번호를 연결해주세요. (예: closes #1234)
