### PR TITLE
fix: 소그룹 챌린지 상세조회시 아바타 조회 관련 수정

### DIFF
--- a/src/main/java/org/scoula/challenge/dto/ChallengeMemberDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeMemberDTO.java
@@ -1,12 +1,17 @@
 package org.scoula.challenge.dto;
 
-import lombok.Builder;
 import lombok.Data;
 
-@Data // 기본 생성자 + setter 제공
+@Data
 public class ChallengeMemberDTO {
     private Long userId;
     private String nickname;
     private Double progress;
-    private String avatarImage;
+
+    // 레이어드 아바타용 파츠 ID들
+    private Long levelId;
+    private Long topId;
+    private Long shoesId;
+    private Long accessoryId;
+    private Long giftCardId;
 }

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -71,16 +71,25 @@
         WHERE user_id = #{userId} AND challenge_id = #{challengeId}
     </select>
 
-    <select id="getGroupMembersWithAvatar" resultType="org.scoula.challenge.dto.ChallengeMemberDTO">
-        SELECT u.id AS userId,
-               us.nickname AS nickname,
-               (uc.actual_value * 1.0 / c.goal_value) AS progress,
-               a.avatar_image AS avatarImage
+    <select id="getGroupMembersWithAvatar"
+            resultType="org.scoula.challenge.dto.ChallengeMemberDTO">
+        SELECT
+        u.id  AS userId,
+        us.nickname AS nickname,
+        CASE
+        WHEN c.goal_value IS NULL OR c.goal_value = 0 THEN 0
+        ELSE uc.actual_value * 1.0 / c.goal_value
+        END AS progress,
+        a.level_id     AS levelId,
+        a.top_id       AS topId,
+        a.shoes_id     AS shoesId,
+        a.accessory_id AS accessoryId,
+        a.gift_card_id AS giftCardId
         FROM user_challenge uc
-                 JOIN user u ON uc.user_id = u.id
-                 JOIN user_status us ON u.id = us.id
-                 JOIN challenge c ON uc.challenge_id = c.id
-                 LEFT JOIN avatar a ON u.id = a.id
+        JOIN user u        ON uc.user_id = u.id
+        JOIN user_status us ON us.id = u.id
+        JOIN challenge c    ON c.id = uc.challenge_id
+        LEFT JOIN avatar a  ON a.id = u.id
         WHERE uc.challenge_id = #{challengeId}
     </select>
 


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약

* 그룹 챌린지 상세 조회 시 발생하던 **500 오류**(`a.avatar_image` 컬럼 불일치) 해결
* 멤버 아바타 전달 방식을 **이미지 URL → 파츠 ID 레이어링**으로 변경 (FE에서 합성)
* 진행률 계산 시 **goal\_value NULL/0 가드** 추가
* DB 스키마 변경 없음, 마이그레이션 없음

## 📖 작업 내용

* **DTO 변경**

  * `ChallengeMemberDTO`

    * 제거: `avatarImage:String`
    * 추가: `levelId:Long`, `topId:Long`, `shoesId:Long`, `accessoryId:Long`, `giftCardId:Long`
* **Mapper 쿼리 수정** (`ChallengeMapper.xml`)

  * `getGroupMembersWithAvatar`

    * `LEFT JOIN avatar a ON a.id = u.id`
    * SELECT 컬럼에 파츠 ID 5종 추가
    * `a.avatar_image` 조회 제거
    * `progress` 계산 시 `goal_value`가 NULL/0인 경우 0 처리
* **Service/Controller**

  * 반환 스키마 유지(`ChallengeDetailResponseDTO`)하되, GROUP의 `members[]` 필드 구조만 변경
* **API 응답 변화 (요지)**

  * `members[].avatarImage` → 제거
  * `members[].levelId/topId/shoesId/accessoryId/giftCardId` → 추가
* **스키마/마이그레이션**

  * 변경 없음 (기존 `avatar` 테이블 구조 사용)

> 예시

```json
"members": [
  {
    "userId": 101,
    "nickname": "보노보노",
    "progress": 0.53,
    "levelId": 1,
    "topId": null,
    "shoesId": null,
    "accessoryId": 2,
    "giftCardId": null
  }
]
```

## ✅ 체크리스트

* [ ] 커밋 컨벤션 준수
* [ ] 로컬 환경에서 동작 확인 완료
* [ ] 리뷰어 n명 이상 승인 완료
* [ ] 문서화가 필요한 경우 추가했습니다.
* [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

* FE는 파츠 ID → S3 경로 매핑을 컴포넌트에서 관리 예정입니다. **향후 BE에서 정적 매핑 API**(또는 CDN JSON)로 제공해 FE 하드코딩을 줄이는 방향 어떤가요?
* `avatar` 레코드가 없는 유저는 파츠 ID가 전부 `null`로 내려갑니다. 이 경우 FE는 이니셜 fallback으로 표시하도록 합의했습니다. 기본 레벨(예: `levelId=1`)을 BE에서 강제 세팅할까요, 현행 유지할까요?
* `top/shoes/giftCard`의 실제 파일매핑(아이디→파일명)이 확정되면 공유 부탁드립니다. 현재는 `level/accessory`만 사용 사례 존재합니다.

## 🔗 관련 이슈

- closes #198 
