### PR TITLE
fix: 챌린지, 코인, 회원가입 등 다양하게 수정

### DIFF
--- a/src/main/java/org/scoula/challenge/dto/StockRecommendationDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/StockRecommendationDTO.java
@@ -1,13 +1,19 @@
 package org.scoula.challenge.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@Builder                // ★ 빌더 추가
+@NoArgsConstructor      // ★ 직렬화/역직렬화 대비
+@AllArgsConstructor
 public class StockRecommendationDTO {
     private String stockCode;
     private String stockName;
     private String stockReturnsData;
-    private int stockPrice;
+    private int    stockPrice;
     private String stockMarketType;
     private String stockPredictedPrice;
     private String stockChangeRate;

--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -73,7 +73,7 @@ public interface ChallengeMapper {
 
     // 챌린지 결과 확인 관련 메서드
     int getActualValue(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
-    int getActualRewardPoint(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
+    Integer getActualRewardPoint(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
     void markResultChecked(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
     boolean existsUnconfirmedCompletedChallenge(@Param("userId") Long userId);
     Boolean isResultChecked(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
@@ -87,5 +87,8 @@ public interface ChallengeMapper {
                                @Param("actualRewardPoint") int actualRewardPoint);
 
     List<ChallengeHistoryItemDTO> findCompletedHistoryByUser(@Param("userId") Long userId);
+
+    // 성공 여부 조회
+    Boolean getIsSuccess(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
 }
 

--- a/src/main/java/org/scoula/coin/controller/CoinController.java
+++ b/src/main/java/org/scoula/coin/controller/CoinController.java
@@ -3,6 +3,7 @@ package org.scoula.coin.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.scoula.coin.dto.CoinMonthlyResponseDTO;
+import org.scoula.coin.dto.CoinStatusResponseDTO;
 import org.scoula.coin.service.CoinService;
 import org.scoula.common.dto.CommonResponseDTO;
 import org.scoula.security.account.domain.CustomUserDetails;
@@ -25,5 +26,13 @@ public class CoinController {
         Long userId = user.getUserId();
         CoinMonthlyResponseDTO dto = coinService.getMyMonthlyCoin(userId);
         return CommonResponseDTO.success("월별 누적 포인트 조회 성공", dto);
+    }
+
+    @GetMapping("/status")
+    public CommonResponseDTO<CoinStatusResponseDTO> getMyCoinStatus(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        Long userId = user.getUserId();
+        return CommonResponseDTO.success("코인 상태 조회 성공",
+                coinService.getMyCoinStatus(userId));
     }
 }

--- a/src/main/java/org/scoula/coin/dto/CoinStatusResponseDTO.java
+++ b/src/main/java/org/scoula/coin/dto/CoinStatusResponseDTO.java
@@ -1,0 +1,14 @@
+package org.scoula.coin.dto;
+
+import lombok.*;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoinStatusResponseDTO {
+    private long amount;                 // 현재 포인트
+    private long cumulativeAmount;       // 누적 포인트(챌린지+퀴즈)
+    private long monthlyCumulativeAmount;// 이달 누적(챌린지)
+    private String updatedAt;            // 갱신시각(선택)
+}

--- a/src/main/java/org/scoula/coin/enums/CoinType.java
+++ b/src/main/java/org/scoula/coin/enums/CoinType.java
@@ -1,0 +1,6 @@
+// org.scoula.coin.enums.CoinType.java
+package org.scoula.coin.enums;
+
+public enum CoinType {
+    QUIZ, CHALLENGE, AVATAR, GIFTICON, WELCOME, INVITE
+}

--- a/src/main/java/org/scoula/coin/mapper/CoinMapper.java
+++ b/src/main/java/org/scoula/coin/mapper/CoinMapper.java
@@ -1,6 +1,7 @@
 package org.scoula.coin.mapper;
 
 import org.apache.ibatis.annotations.Param;
+import org.scoula.coin.dto.CoinStatusResponseDTO;
 
 public interface CoinMapper {
     void subtractCoin(@Param("userId") Long userId, @Param("amount") int amount);
@@ -21,5 +22,12 @@ public interface CoinMapper {
     // 챌린지 홈 슬라이드에서 활용 월별 누적데이터
     Long getMonthlyCumulativeAmount(@Param("userId") Long userId);
     String getUpdatedAt(@Param("userId") Long userId);
+
+    CoinStatusResponseDTO getCoinStatus(@Param("userId") Long userId);
+
+    // 신규: 축하금 등 월누적 제외 증가용
+    void addCoinAmountExceptMonthly(@Param("userId") Long userId, @Param("amount") int amount);
+
+
 }
 

--- a/src/main/java/org/scoula/coin/service/CoinService.java
+++ b/src/main/java/org/scoula/coin/service/CoinService.java
@@ -1,7 +1,9 @@
 package org.scoula.coin.service;
 
 import org.scoula.coin.dto.CoinMonthlyResponseDTO;
+import org.scoula.coin.dto.CoinStatusResponseDTO;
 
 public interface CoinService {
     CoinMonthlyResponseDTO getMyMonthlyCoin(Long userId);
+    CoinStatusResponseDTO getMyCoinStatus(Long userId);
 }

--- a/src/main/java/org/scoula/coin/service/CoinServiceImpl.java
+++ b/src/main/java/org/scoula/coin/service/CoinServiceImpl.java
@@ -2,6 +2,7 @@ package org.scoula.coin.service;
 
 import lombok.RequiredArgsConstructor;
 import org.scoula.coin.dto.CoinMonthlyResponseDTO;
+import org.scoula.coin.dto.CoinStatusResponseDTO;
 import org.scoula.coin.mapper.CoinMapper;
 import org.springframework.stereotype.Service;
 
@@ -26,5 +27,17 @@ public class CoinServiceImpl implements CoinService {
                 .amount(amount == null ? 0L : amount)
                 .updatedAt(updatedAt)
                 .build();
+    }
+
+    @Override
+    public CoinStatusResponseDTO getMyCoinStatus(Long userId) {
+        CoinStatusResponseDTO dto = coinMapper.getCoinStatus(userId);
+        if (dto == null) {
+            // coin row가 없다면 0으로 초기화 반환
+            return CoinStatusResponseDTO.builder()
+                    .amount(0).cumulativeAmount(0).monthlyCumulativeAmount(0)
+                    .updatedAt(null).build();
+        }
+        return dto;
     }
 }

--- a/src/main/java/org/scoula/user/service/UserServiceImpl.java
+++ b/src/main/java/org/scoula/user/service/UserServiceImpl.java
@@ -49,6 +49,8 @@ public class UserServiceImpl implements UserService {
     private final Logger log = LoggerFactory.getLogger(UserService.class);
     private final AvatarService avatarService;
 
+    private static final int WELCOME_BONUS = 100; // ★ 축하금
+
     // mysql 연결 테스트용
     public User getTestUser() {
         return userMapper.selectFirstUser();
@@ -98,6 +100,13 @@ public class UserServiceImpl implements UserService {
 
         // 3. coin row 초기화
         coinMapper.insertInitialCoin(user.getId());
+
+        // ★ 3-1. 회원가입 축하금 지급 (월누적 미반영)
+        coinMapper.addCoinAmountExceptMonthly(user.getId(), WELCOME_BONUS);
+        coinMapper.insertCoinHistory(user.getId(), WELCOME_BONUS, "plus", "WELCOME");
+
+        // (선택) 누적 포인트에 따른 레벨업 체크까지 즉시 반영하려면 아래 한 줄 활성화
+        // checkAndLevelUp(user.getId());
 
         // 4. 챌린지 요약 초기화
         userMapper.insertUserChallengeSummary(user.getId());

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -18,11 +18,15 @@
     </insert>
 
     <select id="countUserOngoingChallenges" resultType="int">
-        SELECT COUNT(*) FROM user_challenge uc
-                                 JOIN challenge c ON uc.challenge_id = c.ID
+        SELECT COUNT(1)
+        FROM user_challenge uc
+                 JOIN challenge c ON c.id = uc.challenge_id
         WHERE uc.user_id = #{userId}
           AND c.type = #{type}
-          AND c.status IN ('RECRUITING', 'IN_PROGRESS')
+          AND (
+            c.status IN ('RECRUITING','IN_PROGRESS')
+                OR (c.status = 'COMPLETED' AND uc.result_checked = 0)
+            )
     </select>
 
     <select id="findChallenges" resultType="org.scoula.challenge.domain.Challenge">
@@ -179,7 +183,7 @@
         WHERE user_id = #{userId} AND challenge_id = #{challengeId}
     </select>
 
-    <select id="getActualRewardPoint" resultType="int">
+    <select id="getActualRewardPoint" resultType="java.lang.Integer">
         SELECT actual_reward_point FROM user_challenge
         WHERE user_id = #{userId} AND challenge_id = #{challengeId}
     </select>
@@ -242,6 +246,12 @@
         WHERE uc.user_id = #{userId}
           AND uc.is_completed = 1
         ORDER BY uc.updated_at DESC
+    </select>
+
+    <select id="getIsSuccess" resultType="boolean">
+        SELECT COALESCE(uc.is_success, 0)
+        FROM user_challenge uc
+        WHERE uc.user_id = #{userId} AND uc.challenge_id = #{challengeId}
     </select>
 
 

--- a/src/main/resources/org/scoula/coin/mapper/CoinMapper.xml
+++ b/src/main/resources/org/scoula/coin/mapper/CoinMapper.xml
@@ -49,4 +49,24 @@
         WHERE id = #{userId}
     </select>
 
+    <select id="getCoinStatus" resultType="org.scoula.coin.dto.CoinStatusResponseDTO">
+        SELECT
+            COALESCE(amount, 0)                    AS amount,
+            COALESCE(cumulative_amount, 0)         AS cumulativeAmount,
+            COALESCE(monthly_cumulative_amount, 0) AS monthlyCumulativeAmount,
+            DATE_FORMAT(updated_at, '%Y-%m-%d %H:%i:%s') AS updatedAt
+        FROM coin
+        WHERE id = #{userId}
+    </select>
+
+    <!-- 신규: amount, cumulative_amount만 증가 (monthly_cumulative_amount 미반영) -->
+    <update id="addCoinAmountExceptMonthly">
+        UPDATE coin
+        SET amount = amount + #{amount},
+            cumulative_amount = cumulative_amount + #{amount}
+        WHERE id = #{userId}
+    </update>
+
+
+
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request (백엔드 전용)

## 👀 작업 요약

* **회원가입 시 축하금 100P 자동 지급**: 잔액·누적 반영(월누적 제외) + `coin_history` 기록
* **`registerUser` 트랜잭션 처리**로 초기화/지급/부가 데이터 생성 일관성 보장
* (이전 작업 포함, 상세 기술)

  * **챌린지**: 진행중 판정 통일, 결과 처리 2단계(계산/지급 분리), 요약 갱신 시 `updated_at` 관리
  * **코인**: `/api/coin/status` 도입으로 코인 스냅샷 제공, `coin_history` 타입 확장

## 📖 작업 내용

### Coin

* **신규 지급 메서드(월누적 제외)**

  * `CoinMapper.addCoinAmountExceptMonthly(userId, amount)` 추가
  * `CoinMapper.xml`에 `amount`, `cumulative_amount`만 증가하도록 UPDATE 문 추가
  * 목적: \*\*축하금은 월누적(챌린지 전용)\*\*에 포함하지 않기 위함
* **코인 내역 기록**

  * 축하금 지급 시 `coin_history`에 `type='plus'`, `coin_type='WELCOME'` 기록
  * DB 마이그레이션: `coin_history.coin_type`에 `WELCOME` 추가

    ```sql
    ALTER TABLE coin_history
      MODIFY COLUMN coin_type ENUM('QUIZ','CHALLENGE','AVATAR','GIFTICON','WELCOME') NOT NULL;
    ```
* **코인 스냅샷 API**

  * `GET /api/coin/status` 추가
  * `CoinStatusResponseDTO { amount, cumulativeAmount, monthlyCumulativeAmount, updatedAt }`
  * `CoinMapper.getCoinStatus`, `CoinService.getMyCoinStatus`, `CoinController /status`
* **지급 정책 정리**

  * **챌린지/퀴즈 등의 보상**: `addCoinAmount` 사용(잔액/누적/**월누적** 모두 증가)
  * **가입 축하금**: `addCoinAmountExceptMonthly` 사용(잔액/누적만 증가)

### User

* **회원가입 축하금 100P 자동 지급**

  * `UserServiceImpl.registerUser`에서 `insertInitialCoin` 직후 **축하금 100P** 지급
  * `coin_history`에 `WELCOME` 기록
  * (선택) `checkAndLevelUp(userId)` 호출 주석 추가 — 정책에 따라 즉시 레벨 반영 가능
* **트랜잭션 적용**

  * `@Transactional`로 회원/코인/요약/아바타/동의 등 **다중 테이블 일괄 반영**

---

### 참고(이전 PR 포함 — 상세 기술)

#### ✅ 챌린지(Challenge)

* **진행 중 판정 통일**

  * 진행 중 = `RECRUITING` 또는 `IN_PROGRESS` 또는 **`COMPLETED && result_checked=0`**
  * 적용 위치: `countUserOngoingChallenges`(생성/참여 제한의 단일 소스)
* **결과 처리 2단계 분리**

  1. `GET /api/challenge/{id}/result`

     * `is_completed=1`, `is_success` 산정 저장
     * `actual_reward_point` 저장
     * **코인 지급 없음**
  2. `PATCH /api/challenge/{id}/result/confirm` (**멱등**)

     * 이미 `result_checked=1`이면 **조기 종료**
     * 미계산 시 `getChallengeResult`로 보상 재계산
     * `addCoinAmount`로 **코인 지급**(잔액/누적/월누적 동시 증가) + `coin_history(type='plus', coin_type='CHALLENGE')`
     * `user_challenge_summary` 갱신: `insertOrUpdate` → 성공 시 `success_count +1` → `achievement_rate` 재계산
     * 마지막에 `result_checked=1`
* **참여/생성 시 요약 반영**

  * 생성자/참여자 모두 `total_challenges +1`, `achievement_rate` 재계산
* **추천 주식 전달**

  * `StockListDto` → `StockRecommendationDTO` **빌더로 1:1 매핑**(필드 전체 전달)
* **요약 테이블 시간 갱신**

  * `user_challenge_summary.updated_at`을 **DDL의 ON UPDATE** 또는 \*\*Mapper의 `updated_at=CURRENT_TIMESTAMP`\*\*로 갱신하도록 반영

#### ✅ 코인(Coin)

* **코인 스냅샷 API 도입**

  * `GET /api/coin/status`: 프론트 Pinia가 로그인/앱 초기화 시 1회 로드하여 전역 상태로 사용
* **코인 지급 기준 통일**

  * 챌린지 보상은 `/result/confirm` 시점 **단일 경로**로 지급(중복 지급 방지)
  * `coin_history` 타입 체계화: `CHALLENGE`, `QUIZ`, `AVATAR`, `GIFTICON`, **`WELCOME`(신규)**, **`INVITE`(신규)**

---

## ✅ 체크리스트

* [ ] 커밋 컨벤션 준수
* [ ] 로컬 환경에서 동작 확인 완료
* [ ] 리뷰어 n명 이상 승인 완료
* [ ] 문서화가 필요한 경우 추가했습니다.
* [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

* 가입 축하금 100P는 **누적 포인트(cumulative)** 에 반영하는 것으로 이해하고 반영했습니다.
  가입 직후 **레벨/아바타 즉시 반영**이 필요하면 `registerUser` 내 `checkAndLevelUp(userId)` 호출을 활성화할까요?

- 나중에 친구 초대 +  회원가입시 초대 수당 추가할까 싶어서 INVITE 도 추가해뒀습니다

## 🔗 관련 이슈

* closes #201
* closes #202
* closes #203 
