### PR TITLE
fix: 챌린지 홈 참여중 리스트 조회 로직 및 챌린지 개수 제한 로직 수정

### DIFF
--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -24,7 +24,7 @@
         WHERE uc.user_id = #{userId}
           AND c.type = #{type}
           AND (
-            c.status IN ('RECRUITING','IN_PROGRESS')
+            c.status IN ('RECRUITING','IN_PROGRESS', 'CLOSED')
                 OR (c.status = 'COMPLETED' AND uc.result_checked = 0)
             )
     </select>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약

* 개인/그룹 챌린지 “최대 3개” 참여 제한이 뚫리던 이슈 수정
* 진행중 카운트 쿼리에 `CLOSED` 상태 포함
* (선택) 개인 챌린지 생성 시 시작일 기준 상태 분기(`IN_PROGRESS`/`CLOSED`)로 의미론 보강

## 📖 작업 내용

* `ChallengeMapper.xml`

  * `countUserOngoingChallenges` 쿼리에서 진행중 판정 범위를 확대

    * 변경: `RECRUITING`, `IN_PROGRESS`, **`CLOSED`** 포함 + `COMPLETED & !result_checked`
* (선택) `ChallengeServiceImpl`

  * 개인 챌린지 생성 시 `startDate`가 오늘/과거면 `IN_PROGRESS`, 미래면 `CLOSED`로 저장하도록 분기

### 변경 파일

* `org/scoula/challenge/mapper/ChallengeMapper.xml`
* *(선택)* `org/scoula/challenge/service/ChallengeServiceImpl.java`

### 테스트 방법

1. 동일 유저로 개인 챌린지 3개 생성 → 4번째 생성 시도

   * 기대: `ChallengeLimitExceededException` (400) 발생
2. 그룹 챌린지도 동일 시나리오로 검증
3. 완료되었지만 결과 미확인 챌린지가 있는 경우 카운트에 포함되는지 확인
4. (선택 변경 반영 시) 개인 챌린지 생성 시 시작일에 따라 상태가 `IN_PROGRESS`/`CLOSED`로 적절히 저장되는지 확인

### 스크린샷/로그(선택)

* Swagger 호출 응답 캡처 첨부
* DB 쿼리/카운트 로그 필요 시 추가

## ✅ 체크리스트

* [ ] 커밋 컨벤션 준수
* [ ] 로컬 환경에서 동작 확인 완료
* [ ] 리뷰어 n명 이상 승인 완료
* [ ] 문서화가 필요한 경우 추가했습니다.
* [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

* 개인 챌린지 생성 시 상태 분기(의미론 보강) 옵션을 기본 채택할지?

## 🔗 관련 이슈

* closes #207 
