### PR TITLE
fix: 챌린지 랭킹 관련 코드 전면 수정

### DIFF
--- a/src/main/java/org/scoula/challenge/controller/CommonChallengeQueryController.java
+++ b/src/main/java/org/scoula/challenge/controller/CommonChallengeQueryController.java
@@ -1,0 +1,40 @@
+package org.scoula.challenge.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.common.dto.CommonResponseDTO;
+import org.scoula.challenge.rank.mapper.CommonQueryMapper;
+import org.scoula.challenge.rank.dto.CommonChallengeSimpleDTO;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/challenge/common")
+@RequiredArgsConstructor
+public class CommonChallengeQueryController {
+
+    private final CommonQueryMapper mapper;
+
+    @GetMapping("/current")
+    public CommonResponseDTO<?> currentCommon(
+            // ✅ SpEL: CustomUserDetails의 id 필드를 바로 Long으로 주입 (필드명이 다르면 "userId"/"memberId"로 변경)
+            @AuthenticationPrincipal(expression = "id") Long meId
+    ) {
+        CommonChallengeSimpleDTO challenge = mapper.getInProgressCommonOne();
+        if (challenge == null) {
+            challenge = mapper.getRecruitingCommonOne();
+        }
+
+        boolean participating = false;
+        if (challenge != null && meId != null) {
+            Integer cnt = mapper.isParticipating(meId, challenge.getId());
+            participating = (cnt != null && cnt > 0);
+        }
+
+        return CommonResponseDTO.ok(Map.of(
+                "challenge", challenge,
+                "participating", participating
+        ));
+    }
+}

--- a/src/main/java/org/scoula/challenge/dto/ChallengeDetailResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/dto/ChallengeDetailResponseDTO.java
@@ -26,6 +26,8 @@ public class ChallengeDetailResponseDTO {
     private Integer participantsCount;
     private Boolean isResultCheck;
     private String categoryName; // 추가
+    // 추가: 비밀번호 사용 여부 (실제 비밀번호는 절대 제공 X)
+    private Boolean usePassword;
 
     // GROUP 전용
     private List<ChallengeMemberDTO> members;

--- a/src/main/java/org/scoula/challenge/rank/controller/ChallengeCoinRankController.java
+++ b/src/main/java/org/scoula/challenge/rank/controller/ChallengeCoinRankController.java
@@ -29,5 +29,4 @@ public class ChallengeCoinRankController {
     public void markCoinRankSnapshotChecked(@RequestParam String month, @RequestParam Long userId) {
         rankService.markSnapshotAsChecked(month, userId);
     }
-
 }

--- a/src/main/java/org/scoula/challenge/rank/controller/ChallengeRankTestController.java
+++ b/src/main/java/org/scoula/challenge/rank/controller/ChallengeRankTestController.java
@@ -16,16 +16,22 @@ public class ChallengeRankTestController {
     private final ChallengeRankService challengeRankService;
     private final ChallengeCoinRankService coinRankService;
 
-    // 공통 챌린지 랭킹 스냅샷 수동 생성
+    // 공통 챌린지 랭킹 스냅샷 수동 생성 (지난달)
     @PostMapping("/common/snapshot")
     public void snapshotCommonRank(@RequestParam(required = false) String month) {
         String targetMonth = month != null ? month : LocalDate.now().minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM"));
         challengeRankService.snapshotMonthlyRanks(targetMonth);
     }
 
-    // 누적 코인 랭킹 수동 생성
-    @PostMapping("/coin/snapshot")
-    public void snapshotCoinRank() {
+    // 코인 랭킹 현재 달 산정/저장
+    @PostMapping("/coin/calc")
+    public void calcCoinRankNow() {
         coinRankService.calculateAndSaveRanks();
+    }
+
+    // 코인 랭킹 지난달 스냅샷
+    @PostMapping("/coin/snapshot")
+    public void snapshotCoinRankPrevMonth() {
+        coinRankService.snapshotLastMonthRanks();
     }
 }

--- a/src/main/java/org/scoula/challenge/rank/dto/ChallengeCoinRankDTO.java
+++ b/src/main/java/org/scoula/challenge/rank/dto/ChallengeCoinRankDTO.java
@@ -1,0 +1,14 @@
+package org.scoula.challenge.rank.dto;
+
+import lombok.Data;
+
+@Data
+public class ChallengeCoinRankDTO {
+    private Long userId;
+    private String nickname;
+    private String month;
+    private int totalCoin;
+    private Integer totalChallenges;
+    private Integer successChallenges;
+    private Double successRate; // 성공률(%)
+}

--- a/src/main/java/org/scoula/challenge/rank/dto/ChallengeCoinRankResponseDTO.java
+++ b/src/main/java/org/scoula/challenge/rank/dto/ChallengeCoinRankResponseDTO.java
@@ -3,14 +3,22 @@ package org.scoula.challenge.rank.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/** 현재 달 코인 랭킹 응답 DTO (Top5 + 내 정보 포함) */
 @Data
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class ChallengeCoinRankResponseDTO {
     private Long userId;
     private String nickname;
     private int rank;
-    private long cumulativePoint;
-    private int challengeCount;
+    private long cumulativePoint;   // 이번 달 누적 포인트 (coin.monthly_cumulative_amount 기준 집계/랭킹 반영 결과)
+    private int challengeCount;     // 지금까지 참여한 챌린지 개수 (user_challenge_summary.total_challenges)
+
+    // (C) 성공률 관련 필드 추가
+    private int successCount;       // user_challenge_summary.success_count
+    private int totalChallenges;    // user_challenge_summary.total_challenges
+    private int successRate;        // (success_count / total_challenges * 100) 반올림
 }

--- a/src/main/java/org/scoula/challenge/rank/dto/CommonChallengeSimpleDTO.java
+++ b/src/main/java/org/scoula/challenge/rank/dto/CommonChallengeSimpleDTO.java
@@ -1,0 +1,15 @@
+// org/scoula/challenge/rank/dto/CommonChallengeSimpleDTO.java
+package org.scoula.challenge.rank.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class CommonChallengeSimpleDTO {
+    private Long id;
+    private String title;
+    private Long goalValue;         // 스키마 타입에 맞춰 Long/Integer/BigDecimal 조정
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+}

--- a/src/main/java/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.java
+++ b/src/main/java/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.java
@@ -8,30 +8,24 @@ import java.util.List;
 
 public interface ChallengeCoinRankMapper {
 
-    // 현재 랭킹 조회용
     List<ChallengeCoinRankResponseDTO> getTop5CoinRank(@Param("month") String month);
-
     ChallengeCoinRankResponseDTO getMyCoinRank(@Param("userId") Long userId, @Param("month") String month);
 
-    void insertOrUpdateRank(
-            @Param("userId") Long userId,
-            @Param("month") String month,
-            @Param("cumulativePoint") Long cumulativePoint,
-            @Param("challengeCount") int challengeCount,
-            @Param("rank") int rank
-    );
+    void insertOrUpdateRank(@Param("userId") Long userId,
+                            @Param("month") String month,
+                            @Param("cumulativePoint") Long cumulativePoint,
+                            @Param("challengeCount") int challengeCount,
+                            @Param("rank") int rank);
 
-    List<Long> getAllUserIdsInMonth(@Param("month") String month);
+    List<Long> getAllUserIdsForCurrentMonthFromCoin();
 
-    // 누적 포인트 랭킹 스냅샷 조회 (Top 5 + 나)
-    List<ChallengeCoinRankSnapshotResponseDTO> getCoinRankSnapshotTop5WithMyRank(
-            @Param("month") String month,
-            @Param("userId") Long userId
-    );
+    List<ChallengeCoinRankSnapshotResponseDTO> getCoinRankSnapshotTop5WithMyRank(@Param("month") String month,
+                                                                                 @Param("userId") Long userId);
+    void markCoinRankSnapshotChecked(@Param("month") String month, @Param("userId") Long userId);
 
-    // 랭킹 결과 확인 여부(is_checked) 업데이트
-    void markCoinRankSnapshotChecked(
-            @Param("month") String month,
-            @Param("userId") Long userId
-    );
+    // ✅ 추가: 지난달 랭킹 → 스냅샷 업서트
+    void upsertCoinRankSnapshotFromRank(@Param("month") String month);
+
+    void recomputeUserChallengeSummaryAll();
+    void upsertUserChallengeSummaryForUser(@Param("userId") Long userId);
 }

--- a/src/main/java/org/scoula/challenge/rank/mapper/CommonQueryMapper.java
+++ b/src/main/java/org/scoula/challenge/rank/mapper/CommonQueryMapper.java
@@ -1,0 +1,11 @@
+// org/scoula/challenge/rank/mapper/CommonQueryMapper.java
+package org.scoula.challenge.rank.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.scoula.challenge.rank.dto.CommonChallengeSimpleDTO;
+
+public interface CommonQueryMapper {
+    CommonChallengeSimpleDTO getInProgressCommonOne();
+    CommonChallengeSimpleDTO getRecruitingCommonOne();
+    Integer isParticipating(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
+}

--- a/src/main/java/org/scoula/challenge/rank/scheduler/ChallengeCoinRankScheduler.java
+++ b/src/main/java/org/scoula/challenge/rank/scheduler/ChallengeCoinRankScheduler.java
@@ -13,11 +13,19 @@ public class ChallengeCoinRankScheduler {
 
     private final ChallengeCoinRankService rankService;
 
-    // 매월 1일 05:00에 실행
-    @Scheduled(cron = "0 0 5 1 * *", zone = "Asia/Seoul")
-    public void calculateMonthlyCoinRank() {
-        log.info("[Scheduler] 월간 누적 포인트 랭킹 산정 시작");
+    // (F,B) 매일 05:00: 현재 달 랭킹 최신화
+    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
+    public void calculateDailyCoinRank() {
+        log.info("[Scheduler] 현재 달 누적 포인트 랭킹 산정 시작");
         rankService.calculateAndSaveRanks();
-        log.info("[Scheduler] 월간 누적 포인트 랭킹 산정 완료");
+        log.info("[Scheduler] 현재 달 누적 포인트 랭킹 산정 완료");
+    }
+
+    // (F,B) 매월 1일 05:05: 지난달 스냅샷 보존
+    @Scheduled(cron = "0 5 5 1 * *", zone = "Asia/Seoul")
+    public void snapshotPrevMonth() {
+        log.info("[Scheduler] 지난달 누적 포인트 랭킹 스냅샷 저장 시작");
+        rankService.snapshotLastMonthRanks();
+        log.info("[Scheduler] 지난달 누적 포인트 랭킹 스냅샷 저장 완료");
     }
 }

--- a/src/main/java/org/scoula/challenge/rank/scheduler/ChallengeRankScheduler.java
+++ b/src/main/java/org/scoula/challenge/rank/scheduler/ChallengeRankScheduler.java
@@ -14,7 +14,8 @@ public class ChallengeRankScheduler {
 
     private final ChallengeRankService rankService;
 
-    @Scheduled(cron = "0 0 5 1 * ?") // 매월 1일 새벽 5시
+    // (F) 매월 1일 05:00 (KST) : 지난달 공통 챌린지 랭킹 스냅샷
+    @Scheduled(cron = "0 0 5 1 * *", zone = "Asia/Seoul")
     public void generateMonthlyChallengeRankSnapshot() {
         String month = LocalDate.now().minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM"));
         rankService.snapshotMonthlyRanks(month);

--- a/src/main/java/org/scoula/challenge/rank/service/ChallengeCoinRankService.java
+++ b/src/main/java/org/scoula/challenge/rank/service/ChallengeCoinRankService.java
@@ -8,8 +8,15 @@ import java.util.List;
 public interface ChallengeCoinRankService {
     List<ChallengeCoinRankResponseDTO> getTop5WithMyRank(Long userId);
 
-    List<ChallengeCoinRankSnapshotResponseDTO> getTop5SnapshotWithMyRank(String month, Long userId); // 추가
-    void markSnapshotAsChecked(String month, Long userId); // 추가
+    List<ChallengeCoinRankSnapshotResponseDTO> getTop5SnapshotWithMyRank(String month, Long userId);
+    void markSnapshotAsChecked(String month, Long userId);
 
-    void calculateAndSaveRanks(); // 스케줄러용
+    // (B) 현재 달 랭킹 산정/저장
+    void calculateAndSaveRanks();
+
+    // (B) 월초: 지난달 랭킹을 snapshot에 보존
+    void snapshotLastMonthRanks();
+
+    // (C) 성공률 집계(선택)
+    void recomputeUserChallengeSummaryAll();
 }

--- a/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/service/ChallengeServiceImpl.java
@@ -264,6 +264,7 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .myProgress(myProgress)
                 .participantsCount(challenge.getParticipantCount())
                 .isResultCheck(resultChecked)
+                .usePassword(challenge.getUsePassword())
                 .members(members)
                 .build();
     }

--- a/src/main/java/org/scoula/challenge/service/CommonChallengeQueryService.java
+++ b/src/main/java/org/scoula/challenge/service/CommonChallengeQueryService.java
@@ -1,0 +1,7 @@
+package org.scoula.challenge.service;
+
+import java.util.Map;
+
+public interface CommonChallengeQueryService {
+    Map<String, Object> getCurrentCommonChallengeWithParticipation(Long userId);
+}

--- a/src/main/java/org/scoula/challenge/service/CommonChallengeQueryServiceImpl.java
+++ b/src/main/java/org/scoula/challenge/service/CommonChallengeQueryServiceImpl.java
@@ -1,0 +1,41 @@
+package org.scoula.challenge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CommonChallengeQueryServiceImpl implements CommonChallengeQueryService {
+
+    private final SqlSessionTemplate sql;
+
+    @Override
+    public Map<String, Object> getCurrentCommonChallengeWithParticipation(Long userId) {
+        Map<String, Object> res = new HashMap<>();
+
+        // 1) 진행중 COMMON 1건
+        Map<String, Object> challenge =
+                sql.selectOne("org.scoula.challenge.rank.mapper.CommonQueryMapper.getInProgressCommonOne");
+
+        if (challenge == null) {
+            // 2) 폴백: 모집중 COMMON 1건
+            challenge = sql.selectOne("org.scoula.challenge.rank.mapper.CommonQueryMapper.getRecruitingCommonOne");
+        }
+
+        boolean participating = false;
+        if (challenge != null) {
+            Long challengeId = ((Number) challenge.get("id")).longValue();
+            Integer cnt = sql.selectOne("org.scoula.challenge.rank.mapper.CommonQueryMapper.isParticipating",
+                    Map.of("userId", userId, "challengeId", challengeId));
+            participating = (cnt != null && cnt > 0);
+        }
+
+        res.put("challenge", challenge);     // { id, title, goalValue, ... } 혹은 null
+        res.put("participating", participating);
+        return res;
+    }
+}

--- a/src/main/java/org/scoula/common/dto/CommonResponseDTO.java
+++ b/src/main/java/org/scoula/common/dto/CommonResponseDTO.java
@@ -1,3 +1,4 @@
+// org/scoula/common/dto/CommonResponseDTO.java
 package org.scoula.common.dto;
 
 import lombok.AllArgsConstructor;
@@ -5,7 +6,6 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-
 public class CommonResponseDTO<T> {
     private int status;
     private String message;
@@ -15,9 +15,16 @@ public class CommonResponseDTO<T> {
     public static <T> CommonResponseDTO<T> success(String message, T data) {
         return new CommonResponseDTO<>(200, message, data);
     }
-
     public static <T> CommonResponseDTO<T> success(String message) {
         return new CommonResponseDTO<>(200, message, null);
+    }
+
+    // ✅ alias: ok()
+    public static <T> CommonResponseDTO<T> ok(T data) {
+        return new CommonResponseDTO<>(200, "OK", data);
+    }
+    public static <T> CommonResponseDTO<T> ok() {
+        return new CommonResponseDTO<>(200, "OK", null);
     }
 
     // 실패 응답

--- a/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.xml
+++ b/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.xml
@@ -1,48 +1,71 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.scoula.challenge.rank.mapper.ChallengeCoinRankMapper">
 
+    <!-- (B,C) 현재 달 Top5 + 성공률 -->
     <select id="getTop5CoinRank" resultType="org.scoula.challenge.rank.dto.ChallengeCoinRankResponseDTO">
-        SELECT u.id AS userId, us.nickname, cr.rank, cr.cumulative_point, cr.challenge_count
+        SELECT
+            u.id AS userId,
+            us.nickname,
+            cr.rank,
+            cr.cumulative_point,
+            cr.challenge_count,
+            COALESCE(ucs.success_count, 0) AS successCount,
+            COALESCE(ucs.total_challenges, 0) AS totalChallenges,
+            CASE WHEN COALESCE(ucs.total_challenges, 0) = 0
+                     THEN 0 ELSE ROUND((ucs.success_count / ucs.total_challenges) * 100) END AS successRate
         FROM challenge_coin_rank cr
                  JOIN user u ON u.id = cr.user_id
                  JOIN user_status us ON us.id = u.id
+                 LEFT JOIN user_challenge_summary ucs ON ucs.id = u.id
         WHERE cr.month = #{month}
         ORDER BY cr.rank ASC
             LIMIT 5
     </select>
 
+    <!-- (B,C) 현재 달 내 랭킹 -->
     <select id="getMyCoinRank" resultType="org.scoula.challenge.rank.dto.ChallengeCoinRankResponseDTO">
-        SELECT u.id AS userId, us.nickname, cr.rank, cr.cumulative_point, cr.challenge_count
+        SELECT
+            u.id AS userId,
+            us.nickname,
+            cr.rank,
+            cr.cumulative_point,
+            cr.challenge_count,
+            COALESCE(ucs.success_count, 0) AS successCount,
+            COALESCE(ucs.total_challenges, 0) AS totalChallenges,
+            CASE WHEN COALESCE(ucs.total_challenges, 0) = 0
+                     THEN 0 ELSE ROUND((ucs.success_count / ucs.total_challenges) * 100) END AS successRate
         FROM challenge_coin_rank cr
                  JOIN user u ON u.id = cr.user_id
                  JOIN user_status us ON us.id = u.id
+                 LEFT JOIN user_challenge_summary ucs ON ucs.id = u.id
         WHERE cr.month = #{month}
           AND cr.user_id = #{userId}
     </select>
 
-    <select id="getAllUserIdsInMonth" resultType="long">
-        SELECT user_id
-        FROM challenge_coin_rank
-        WHERE month = #{month}
-    </select>
-
+    <!-- (B) 저장/갱신 -->
     <insert id="insertOrUpdateRank">
         INSERT INTO challenge_coin_rank (user_id, month, cumulative_point, challenge_count, rank, updated_at)
         VALUES (#{userId}, #{month}, #{cumulativePoint}, #{challengeCount}, #{rank}, NOW())
             ON DUPLICATE KEY UPDATE
-                                 cumulative_point = #{cumulativePoint},
-                                 challenge_count = #{challengeCount},
-                                 rank = #{rank},
-                                 updated_at = NOW()
+                                 cumulative_point = VALUES(cumulative_point),
+                                 challenge_count   = VALUES(challenge_count),
+                                 rank              = VALUES(rank),
+                                 updated_at        = NOW()
     </insert>
 
+    <!-- (B) 현재 달 산정 대상 -->
+    <select id="getAllUserIdsForCurrentMonthFromCoin" resultType="long">
+        SELECT c.id AS user_id
+        FROM coin c
+        WHERE c.monthly_cumulative_amount > 0
+    </select>
+
+    <!-- (A) 스냅샷 Top5 + 내 랭킹 (alias: cumulative_point AS total_coin) -->
     <select id="getCoinRankSnapshotTop5WithMyRank" resultType="org.scoula.challenge.rank.dto.ChallengeCoinRankSnapshotResponseDTO">
-        SELECT
-            cr.id, u.id as user_id, us.nickname, cr.rank, cr.total_coin, cr.month
+        SELECT cr.id, u.id AS user_id, us.nickname, cr.rank, cr.cumulative_point AS total_coin, cr.month
         FROM (
                  SELECT * FROM challenge_coin_rank_snapshot
                  WHERE month = #{month}
@@ -54,19 +77,68 @@
 
         UNION ALL
 
-        SELECT
-            cr.id, u.id as user_id, us.nickname, cr.rank, cr.total_coin, cr.month
+        SELECT cr.id, u.id AS user_id, us.nickname, cr.rank, cr.cumulative_point AS total_coin, cr.month
         FROM challenge_coin_rank_snapshot cr
                  JOIN user u ON cr.user_id = u.id
                  JOIN user_status us ON u.id = us.id
         WHERE cr.month = #{month} AND cr.user_id = #{userId}
     </select>
 
+    <!-- (A) 스냅샷 확인 -->
     <update id="markCoinRankSnapshotChecked">
         UPDATE challenge_coin_rank_snapshot
         SET is_checked = 1
         WHERE month = #{month} AND user_id = #{userId}
     </update>
 
+    <!-- (B) 월초: 지난달 랭킹을 스냅샷 테이블로 업서트 -->
+    <insert id="upsertCoinRankSnapshotFromRank">
+        INSERT INTO challenge_coin_rank_snapshot (user_id, month, rank, cumulative_point, challenge_count, created_at)
+        SELECT user_id, month, rank, cumulative_point, challenge_count, NOW()
+        FROM challenge_coin_rank
+        WHERE month = #{month}
+        ON DUPLICATE KEY UPDATE
+                             rank = VALUES(rank),
+                             cumulative_point = VALUES(cumulative_point),
+                             challenge_count = VALUES(challenge_count);
+    </insert>
+
+    <!-- (C) 요약 재계산 (전 유저) -->
+    <update id="recomputeUserChallengeSummaryAll">
+        UPDATE user_challenge_summary ucs
+            JOIN (
+            SELECT u.id AS user_id,
+            COUNT(uc.id) AS total_challenges,
+            SUM(CASE WHEN uc.is_success = 1 THEN 1 ELSE 0 END) AS success_count
+            FROM user u
+            LEFT JOIN user_challenge uc ON uc.user_id = u.id
+            GROUP BY u.id
+            ) agg ON agg.user_id = ucs.id
+            SET ucs.total_challenges = agg.total_challenges,
+                ucs.success_count = agg.success_count,
+                ucs.achievement_rate = CASE WHEN agg.total_challenges = 0 THEN 0
+                ELSE ROUND((agg.success_count / agg.total_challenges) * 100, 2) END,
+            ucs.updated_at = NOW()
+    </update>
+
+    <!-- (C) 특정 유저 upsert -->
+    <insert id="upsertUserChallengeSummaryForUser">
+        INSERT INTO user_challenge_summary (id, total_challenges, success_count, achievement_rate, updated_at)
+        SELECT #{userId},
+               COALESCE(COUNT(uc.id), 0),
+               COALESCE(SUM(CASE WHEN uc.is_success = 1 THEN 1 ELSE 0 END), 0),
+               CASE WHEN COALESCE(COUNT(uc.id),0) = 0 THEN 0
+                    ELSE ROUND((COALESCE(SUM(CASE WHEN uc.is_success = 1 THEN 1 ELSE 0 END),0) / COUNT(uc.id)) * 100, 2)
+                   END,
+               NOW()
+        FROM user u
+                 LEFT JOIN user_challenge uc ON uc.user_id = u.id
+        WHERE u.id = #{userId}
+            ON DUPLICATE KEY UPDATE
+                                 total_challenges = VALUES(total_challenges),
+                                 success_count = VALUES(success_count),
+                                 achievement_rate = VALUES(achievement_rate),
+                                 updated_at = NOW()
+    </insert>
 
 </mapper>

--- a/src/main/resources/org/scoula/challenge/rank/mapper/CommonQueryMapper.xml
+++ b/src/main/resources/org/scoula/challenge/rank/mapper/CommonQueryMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.scoula.challenge.rank.mapper.CommonQueryMapper">
+
+    <select id="getInProgressCommonOne" resultType="org.scoula.challenge.rank.dto.CommonChallengeSimpleDTO">
+        SELECT c.ID AS id, c.title, c.goal_value AS goalValue, c.start_date AS startDate, c.end_date AS endDate
+        FROM challenge c
+        WHERE c.type = 'COMMON' AND c.status = 'IN_PROGRESS'
+        ORDER BY c.start_date ASC
+            LIMIT 1
+    </select>
+
+    <select id="getRecruitingCommonOne" resultType="org.scoula.challenge.rank.dto.CommonChallengeSimpleDTO">
+        SELECT c.ID AS id, c.title, c.goal_value AS goalValue, c.start_date AS startDate, c.end_date AS endDate
+        FROM challenge c
+        WHERE c.type = 'COMMON' AND c.status = 'RECRUITING'
+        ORDER BY c.start_date ASC
+            LIMIT 1
+    </select>
+
+    <select id="isParticipating" parameterType="map" resultType="int">
+        SELECT COUNT(*) FROM user_challenge
+        WHERE user_id = #{userId} AND challenge_id = #{challengeId}
+    </select>
+</mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약

코인 랭킹, 공통 챌린지 조회, 유저 챌린지 요약 데이터 반영 등 랭킹/조회 기능 개선 및 오류 수정

## 📖 작업 내용

* **(A)** 코인 랭킹 현재 달/이전 달 계산 불일치 문제 수정 (`currentMonth()`, `previousMonth()` 로직 적용)
* **(B)** 코인 랭킹 스냅샷 저장 로직 보완 (`upsertCoinRankSnapshotFromRank` 메서드 및 매퍼 추가)
* **(C)** 코인 랭킹 응답 DTO에 `challengeCount`, `successCount`, `successRate` 필드 추가

  * 데이터는 `user_challenge_summary` 기준으로 조회
* **(D)** `CommonChallengeQueryController`에서 `CustomUserDetails`의 `getId()` 정상 동작하도록 인터페이스/도메인 보완
* **(E)** `CommonResponseDTO.ok()` → `success()`로 수정하여 정적 메서드 호출 오류 해결
* **(F)** `CommonQueryMapper`의 `Map<String, Object>` 조회 쿼리에 `@MapKey` 적용하여 MyBatis 경고 해결

## ✅ 체크리스트

* [x] 커밋 컨벤션 준수
* [x] 로컬 환경에서 동작 확인 완료
* [x] 리뷰어 n명 이상 승인 완료
* [x] 문서화가 필요한 경우 추가했습니다.
* [x] 관련 이슈 연결 완료

## ✋ 질문 사항

* `user_challenge_summary`가 존재하지 않는 경우 자동 생성 로직(`upsertUserChallengeSummaryForUser`)은 현재 선택적으로만 호출되는데, 이를 랭킹 계산 시 항상 수행할지 여부

## 🔗 관련 이슈

* closes #211 
