### PR TITLE
fix: 챌린지 스케쥴링, 소비내역 합계 추가

### DIFF
--- a/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
+++ b/src/main/java/org/scoula/challenge/mapper/ChallengeMapper.java
@@ -1,13 +1,12 @@
 package org.scoula.challenge.mapper;
 
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.scoula.challenge.domain.Challenge;
+import org.scoula.challenge.dto.ChallengeHistoryItemDTO;
 import org.scoula.challenge.dto.ChallengeMemberDTO;
 import org.scoula.challenge.dto.ChallengeSummaryResponseDTO;
 import org.scoula.challenge.enums.ChallengeStatus;
 import org.scoula.challenge.enums.ChallengeType;
-import org.scoula.challenge.dto.ChallengeHistoryItemDTO;
 
 import java.util.List;
 
@@ -44,9 +43,9 @@ public interface ChallengeMapper {
     void updateChallengeStatus(@Param("challengeId") Long challengeId,
                                @Param("status") String status);
 
-    List<Challenge> findAllChallenges(); // 모든 챌린지
+    List<Challenge> findAllChallenges();
 
-    void completeUserChallenges(@Param("challengeId") Long challengeId); // 유저 챌린지 완료 처리
+    void completeUserChallenges(@Param("challengeId") Long challengeId);
 
     List<Long> findUserIdsByChallengeId(@Param("challengeId") Long challengeId);
 
@@ -64,21 +63,16 @@ public interface ChallengeMapper {
 
     ChallengeSummaryResponseDTO getChallengeSummary(@Param("userId") Long userId);
 
-    // 유저별 참여 횟수, 성공률 등 계산하는 메서드
     void insertOrUpdateUserChallengeSummary(@Param("userId") Long userId);
     void incrementUserSuccessCount(@Param("userId") Long userId);
     void incrementUserTotalChallenges(@Param("userId") Long userId);
     void updateAchievementRate(@Param("userId") Long userId);
 
-
-    // 챌린지 결과 확인 관련 메서드
     int getActualValue(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
     Integer getActualRewardPoint(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
     void markResultChecked(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
     boolean existsUnconfirmedCompletedChallenge(@Param("userId") Long userId);
     Boolean isResultChecked(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
-
-    // 챌린지 결과 계산
 
     int countSuccessMembers(@Param("challengeId") Long challengeId);
 
@@ -88,7 +82,15 @@ public interface ChallengeMapper {
 
     List<ChallengeHistoryItemDTO> findCompletedHistoryByUser(@Param("userId") Long userId);
 
-    // 성공 여부 조회
     Boolean getIsSuccess(@Param("userId") Long userId, @Param("challengeId") Long challengeId);
-}
 
+    // ====== ⬇️ 추가 메서드(평가/상태 일괄 처리용) ⬇️ ======
+    List<Challenge> findInProgressChallenges();
+    List<Long> findActiveUsers(@Param("challengeId") Long challengeId);
+
+    List<Challenge> findEndedChallengesNeedingEvaluation();
+
+    void setTodayToInProgress();
+    void setEndedToCompleted();
+    void completeUserChallengesByCompletedChallenge();
+}

--- a/src/main/java/org/scoula/transactions/mapper/LedgerMapper.java
+++ b/src/main/java/org/scoula/transactions/mapper/LedgerMapper.java
@@ -43,5 +43,13 @@ public interface LedgerMapper {
     // 4. 최근 N개월간 가장 많이 쓴 카테고리 Top N
     List<String> selectTopCategories(@Param("userId") Long userId,
                                      @Param("monthCount") int monthCount);
+
+
+    // 추가: 사용자/카테고리/기간합(지출) 집계
+    Integer sumExpenseByUserAndCategoryBetween(@Param("userId") Long userId,
+                                               @Param("category") String category,
+                                               @Param("from") LocalDateTime from,
+                                               @Param("to") LocalDateTime to);
+
 }
 

--- a/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
+++ b/src/main/resources/org/scoula/challenge/mapper/ChallengeMapper.xml
@@ -61,11 +61,6 @@
         WHERE uc.challenge_id = #{challengeId}
     </select>
 
-    <select id="getParticipantsCount" resultType="int">
-        SELECT COUNT(*) FROM user_challenge
-        WHERE challenge_id = #{challengeId}
-    </select>
-
     <select id="findChallengeById" resultType="org.scoula.challenge.domain.Challenge">
         SELECT * FROM challenge WHERE id = #{challengeId}
     </select>
@@ -78,22 +73,21 @@
     <select id="getGroupMembersWithAvatar"
             resultType="org.scoula.challenge.dto.ChallengeMemberDTO">
         SELECT
-        u.id  AS userId,
-        us.nickname AS nickname,
-        CASE
-        WHEN c.goal_value IS NULL OR c.goal_value = 0 THEN 0
-        ELSE uc.actual_value * 1.0 / c.goal_value
-        END AS progress,
-        a.level_id     AS levelId,
-        a.top_id       AS topId,
-        a.shoes_id     AS shoesId,
-        a.accessory_id AS accessoryId,
-        a.gift_card_id AS giftCardId
+            u.id  AS userId,
+            us.nickname AS nickname,
+            CASE WHEN c.goal_value IS NULL OR c.goal_value = 0 THEN 0
+                 ELSE uc.actual_value * 1.0 / c.goal_value
+                END AS progress,
+            a.level_id     AS levelId,
+            a.top_id       AS topId,
+            a.shoes_id     AS shoesId,
+            a.accessory_id AS accessoryId,
+            a.gift_card_id AS giftCardId
         FROM user_challenge uc
-        JOIN user u        ON uc.user_id = u.id
-        JOIN user_status us ON us.id = u.id
-        JOIN challenge c    ON c.id = uc.challenge_id
-        LEFT JOIN avatar a  ON a.id = u.id
+                 JOIN user u        ON uc.user_id = u.id
+                 JOIN user_status us ON us.id = u.id
+                 JOIN challenge c    ON c.id = uc.challenge_id
+                 LEFT JOIN avatar a  ON a.id = u.id
         WHERE uc.challenge_id = #{challengeId}
     </select>
 
@@ -209,20 +203,17 @@
         WHERE user_id = #{userId} AND challenge_id = #{challengeId}
     </select>
 
-    <!-- 성공한 유저 수 조회 -->
     <select id="countSuccessMembers" resultType="int">
         SELECT COUNT(*) FROM user_challenge
         WHERE challenge_id = #{challengeId} AND is_success = 1
     </select>
 
-    <!-- actual_reward_point 저장 -->
     <update id="saveActualRewardPoint">
         UPDATE user_challenge
         SET actual_reward_point = #{actualRewardPoint}
         WHERE user_id = #{userId} AND challenge_id = #{challengeId}
     </update>
 
-    <!-- 완료된(is_completed=1) 챌린지 히스토리: resultType 그대로 사용 -->
     <select id="findCompletedHistoryByUser" resultType="org.scoula.challenge.dto.ChallengeHistoryItemDTO">
         SELECT
             uc.challenge_id              AS challengeId,
@@ -237,12 +228,10 @@
             c.goal_value                 AS goalValue,
             uc.actual_reward_point       AS actualRewardPoint,
             uc.result_checked            AS resultChecked,
-            DATE(uc.updated_at)          AS completedAt     -- ✅ LocalDate 매핑용으로 DATE() 처리
+            DATE(uc.updated_at)          AS completedAt
         FROM user_challenge uc
-            JOIN challenge c
-        ON uc.challenge_id = c.id
-            LEFT JOIN challenge_category cc
-            ON c.category_id = cc.id
+            JOIN challenge c ON uc.challenge_id = c.id
+            LEFT JOIN challenge_category cc ON c.category_id = cc.id
         WHERE uc.user_id = #{userId}
           AND uc.is_completed = 1
         ORDER BY uc.updated_at DESC
@@ -254,5 +243,52 @@
         WHERE uc.user_id = #{userId} AND uc.challenge_id = #{challengeId}
     </select>
 
+    <!-- ====== ⬇️ 추가: 평가/상태 일괄 처리용 쿼리들 ⬇️ ====== -->
 
+    <!-- 진행 중 챌린지 -->
+    <select id="findInProgressChallenges" resultType="org.scoula.challenge.domain.Challenge">
+        SELECT * FROM challenge
+        WHERE status = 'IN_PROGRESS'
+    </select>
+
+    <!-- 해당 챌린지에서 아직 미완료인 사용자 -->
+    <select id="findActiveUsers" resultType="long">
+        SELECT uc.user_id
+        FROM user_challenge uc
+        WHERE uc.challenge_id = #{challengeId}
+          AND uc.is_completed = 0
+    </select>
+
+    <!-- 어제 기준 종료된 챌린지 (최종 평가 필요) -->
+    <select id="findEndedChallengesNeedingEvaluation" resultType="org.scoula.challenge.domain.Challenge">
+        SELECT c.*
+        FROM challenge c
+        WHERE c.end_date &lt; CURDATE()
+    </select>
+
+    <!-- 오늘 시작 챌린지 IN_PROGRESS -->
+    <update id="setTodayToInProgress">
+        UPDATE challenge
+        SET status = 'IN_PROGRESS'
+        WHERE status IN ('RECRUITING','CLOSED')
+          AND start_date = CURDATE()
+    </update>
+
+    <!-- 종료 지난 챌린지 COMPLETED -->
+    <update id="setEndedToCompleted">
+        UPDATE challenge
+        SET status = 'COMPLETED'
+        WHERE status &lt;&gt; 'COMPLETED'
+        AND end_date &lt; CURDATE()
+    </update>
+
+    <!-- COMPLETED 챌린지의 user_challenge 완료 처리(안전망) -->
+    <update id="completeUserChallengesByCompletedChallenge">
+        UPDATE user_challenge uc
+            JOIN challenge c ON uc.challenge_id = c.id
+            SET uc.is_completed = 1,
+                uc.updated_at = NOW()
+        WHERE c.status = 'COMPLETED'
+          AND uc.is_completed = 0
+    </update>
 </mapper>

--- a/src/main/resources/org/scoula/transactions/mapper/LedgerMapper.xml
+++ b/src/main/resources/org/scoula/transactions/mapper/LedgerMapper.xml
@@ -142,11 +142,21 @@
         LIMIT 3
     </select>
 
-
-
-
-
-
+    <!-- 추가: 사용자/카테고리/기간 합계(지출) -->
+    <select id="sumExpenseByUserAndCategoryBetween" resultType="int">
+        SELECT IFNULL(SUM(l.amount), 0)
+        FROM ledger l
+                 JOIN tr_category c ON l.category_id = c.id
+                 LEFT JOIN account a ON l.account_id = a.id
+                 LEFT JOIN card cd ON l.card_id = cd.id
+        WHERE l.user_id = #{userId}
+          AND c.name = #{category}
+          AND l.type = 'EXPENSE'
+          AND (l.account_id IS NULL OR a.is_active = TRUE)
+          AND (l.card_id IS NULL OR cd.is_active = TRUE)
+          AND l.date &gt;= #{from}
+          AND l.date &lt; #{to}
+    </select>
 
 
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약

* 스케줄러 트랜잭션 구조 개선 및 평가 로직 정교화
* 진행 중 챌린지 **조기 실패** 일별 평가 + 종료 후 **최종 평가** 분리
* 상태 변경 쿼리 **멱등/일괄** 처리
* 내부 API 의존(LedgerClient) 제거하고 **Ledger 테이블 직접 합산**으로 전환
* MyBatis XML의 `<` 연산자 이스케이프 처리

## 📖 작업 내용

### 1) 스케줄러 트랜잭션/흐름 리팩토링

* `ChallengeScheduler`

  * `@Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")` 유지, **`@Transactional`을 진입점에 부여**

    * `runDailyChallengeScheduler()`에 `@Transactional` 추가
    * 컨트롤러에서 호출되는 수동 실행 메서드에도 `@Transactional` 부여

      * `updateChallengeStatusesNow()`, `evaluateChallengeSuccessesNow()`
  * 헬퍼 메서드는 **private** + `@Transactional` 제거 (self-invocation 문제 제거)

    * `evaluateEarlyFailsForInProgress()` : 진행 중 챌린지 조기 실패 평가

      * 기간: `[start 00:00 ~ 오늘 00:00)` (스케줄은 KST 04:00 실행)
      * `actual > goal_value` 즉시 실패 처리(`is_success=false, is_completed=1`)
    * `evaluateFinalForEndedChallenges()` : 종료 챌린지 최종 평가

      * 기간: `[start 00:00 ~ (end+1) 00:00)` 전체 구간 합산
      * 최종 성공 시 성공률 집계 반영
  * 상태 업데이트는 마지막에 일괄 수행

    * `processChallengeStatusUpdate(...)`에서 멱등 쿼리 3종 호출

      * 오늘 시작 → `IN_PROGRESS`
      * 종료 지난 챌린지 → `COMPLETED`
      * `COMPLETED` 챌린지의 미완료 사용자 `is_completed=1` 안전망

### 2) 평가 대상/상태 변경용 Mapper 추가

* `ChallengeMapper.java` / `ChallengeMapper.xml`

  * 대상 조회

    * `findInProgressChallenges()` : 진행 중 챌린지
    * `findActiveUsers(challengeId)` : 해당 챌린지의 **미완료 사용자**
    * `findEndedChallengesNeedingEvaluation()` : `end_date &lt; CURDATE()` 종료 챌린지
  * 상태 일괄 쿼리(멱등)

    * `setTodayToInProgress()`
    * `setEndedToCompleted()`
    * `completeUserChallengesByCompletedChallenge()`

### 3) Ledger 합산으로 평가 전환

* `LedgerMapper.java` / `LedgerMapper.xml`

  * **신규**: `sumExpenseByUserAndCategoryBetween(userId, category, from, to)`

    * `ledger` + `tr_category` 조인으로 **지출 합계(EXPENSE)** 계산
    * 계정/카드 비활성 필터 유지
* 스케줄러에서 **LedgerMapper** 사용 → **LedgerClient 의존 제거**

### 4) MyBatis XML 이스케이프/기타

* `<`/`>` 연산자 XML 이스케이프 처리

  * 예) `c.end_date &lt; CURDATE()`, `status &lt;&gt; 'COMPLETED'`
* (권장) MyBatis 설정 확인

  * `mapUnderscoreToCamelCase=true` (snake\_case → camelCase 매핑)
* (권장) 타임존 정렬

  * 스케줄러 `zone="Asia/Seoul"` 지정, DB/JVM도 KST로 맞추는 것을 권장

### 5) 파일별 변경 요약

* `ChallengeSchedulerController.java` : **변경 없음** (수동 트리거 유지)
* `ChallengeScheduler.java` : 트랜잭션 위치 조정, 헬퍼 private, 평가/상태 갱신 흐름 확정
* `ChallengeMapper.java/.xml` : 대상 조회 + 상태 일괄 쿼리 + XML 이스케이프
* `LedgerMapper.java/.xml` : 기간/카테고리별 지출 합계 쿼리 추가

### 6) 테스트 방법

1. 로컬/개발 환경에서 수동 실행

   * `GET /api/challenge/scheduler/check-success-now` (평가)
   * `GET /api/challenge/scheduler/run-now` (상태 갱신)
2. 확인 쿼리

   ```sql
   SELECT id, status FROM challenge WHERE start_date = CURDATE();
   SELECT id, status FROM challenge WHERE end_date &lt; CURDATE();
   SELECT * FROM user_challenge WHERE is_completed = 1 ORDER BY updated_at DESC LIMIT 20;
   ```
3. 조기 실패/최종 평가 케이스 각각에 대해 `actual_value`, `is_success`, `is_completed` 반영 확인

### 7) 성능/운영 권장사항

* 인덱스 권장:

  * `challenge(start_date)`, `challenge(end_date)`, `challenge(status)`
  * `user_challenge(challenge_id, is_completed)`
  * `ledger(user_id, date)`, `tr_category(name)`
* 멱등 쿼리로 **중복 실행 안전** 확보

## ✅ 체크리스트

* [ ] 커밋 컨벤션 준수
* [ ] 로컬 환경에서 동작 확인 완료
* [ ] 리뷰어 n명 이상 승인 완료
* [ ] 문서화가 필요한 경우 추가했습니다.
* [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

* 조기 실패 시 **실패 건수 카운트**가 요약 테이블에 필요할까요? (현재는 성공률만 집계)
* `goal_type` 확장(예: 비율·카테고리 다중 선택)이 예정이라면, 평가식 스위칭을 위한 enum/전략 패턴 도입 검토 어떨까요?

## 🔗 관련 이슈

* closes #165 
* closes #221 