### PR TITLE
feat: 간편비밀번호 생성여부 조회 기능 추가

### DIFF
--- a/src/main/java/org/scoula/user/controller/UserController.java
+++ b/src/main/java/org/scoula/user/controller/UserController.java
@@ -68,4 +68,12 @@ public class UserController {
         return CommonResponseDTO.success("간편비밀번호 재설정이 완료되었습니다.");
     }
 
+    //핀번호 여부 조회
+    @ApiOperation(value = "간편비밀번호 여부 조회 ", notes = "간편비밀번호를 설정했는지 여부를 조회합니다.")
+    @PutMapping("/pin/isCreated")
+    public CommonResponseDTO<Boolean> isPinCreated (@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Boolean isPin=userService.isPin(userDetails.getUserId());
+        return CommonResponseDTO.success("간편비밀번호 설정여부 조회가 완료되었습니다.",isPin);
+    }
+
 }

--- a/src/main/java/org/scoula/user/mapper/UserMapper.java
+++ b/src/main/java/org/scoula/user/mapper/UserMapper.java
@@ -14,6 +14,7 @@ public interface UserMapper {
     void updatePassword(User user); // 비밀번호 재발급
     void insertUserChallengeSummary(@Param("userId") Long userId);
     void updateIsActive(@Param("id") Long id);
+    Boolean getIsPin(Long userId);
 
     void updatePin(User user);
     String getPin(@Param("userId") Long userId);

--- a/src/main/java/org/scoula/user/service/UserService.java
+++ b/src/main/java/org/scoula/user/service/UserService.java
@@ -17,4 +17,5 @@ public interface UserService {
     void setPin(Long userId, PinRequestDTO pinRequestDTO);
     void resetPin(Long userId, PinRequestDTO pinRequestDTO);
     void pinLogin(String email, Long userId, PinRequestDTO pinRequestDTO);
+    Boolean isPin(Long userId);
 }

--- a/src/main/java/org/scoula/user/service/UserServiceImpl.java
+++ b/src/main/java/org/scoula/user/service/UserServiceImpl.java
@@ -258,7 +258,7 @@ public class UserServiceImpl implements UserService {
         userMapper.updatePin(u);
     }
 
-    @ApiOperation(value = "간편비밀번호 일치여부 확인.", notes = "사용자가 입력한 간편비밀번호와 실제 간편비밀번호가 일치하는지 조회합니다.")
+
     @Override
     public void pinLogin(String email, Long userId, PinRequestDTO req) {
 
@@ -271,7 +271,6 @@ public class UserServiceImpl implements UserService {
         }
     }
 
-    @ApiOperation(value = "간편비밀번호 재설정 ", notes = "간편비밀번호를 재설정합니다.")
     @Override
     public void resetPin(Long userId, PinRequestDTO req) {
 
@@ -285,5 +284,10 @@ public class UserServiceImpl implements UserService {
         u.setId(userId);
         u.setAuthPw(encodedPin);
         userMapper.updatePin(u);
+    }
+    //간편비밀번호가 있는 여부 조회
+    @Override
+    public Boolean isPin(Long userId) {
+        return userMapper.getIsPin(userId);
     }
 }

--- a/src/main/resources/org/scoula/user/mapper/UserMapper.xml
+++ b/src/main/resources/org/scoula/user/mapper/UserMapper.xml
@@ -49,4 +49,8 @@
         SELECT auth_pw FROM user WHERE id=#{userId}
     </select>
 
+    <select id="getIsPin" resultType="java.lang.Boolean">
+        SELECT EXISTS (SELECT 1 FROM user WHERE id = #{userId} AND auth_pw IS NOT NULL);
+    </select>
+
 </mapper>


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

간편비밀번호 생성여부에 따른 특정페이지창 접속 통제를 필요함
이에 간편비밀번호 생성여부 조회 기능 추가기능추가 

## 📖 작업 내용 

user 패키지의 컨트롤러에 /api/user/pin/isCreated 루트 생성
서비스에 isPinCreated 메소드 생성

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [x] 문서화가 필요한 경우 추가했습니다.
- [x] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

closes #255
