### PR TITLE
fix: challenge mapper rank 벡틱

### DIFF
--- a/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.xml
+++ b/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeCoinRankMapper.xml
@@ -9,13 +9,13 @@
         SELECT
             u.id AS userId,
             us.nickname,
-            cr.`rank` AS rank,
-            cr.cumulative_point AS cumulativePoint,
-            cr.challenge_count AS challengeCount,
-            COALESCE(ucs.success_count, 0) AS successCount,
-            COALESCE(ucs.total_challenges, 0) AS totalChallenges,
-            CASE WHEN COALESCE(ucs.total_challenges, 0) = 0
-                     THEN 0 ELSE ROUND((ucs.success_count / ucs.total_challenges) * 100) END AS successRate
+            cr.`rank`                  AS `rank`,
+            cr.cumulative_point        AS cumulativePoint,
+            cr.challenge_count         AS challengeCount,
+            COALESCE(ucs.success_count, 0)   AS successCount,
+            COALESCE(ucs.total_challenges,0) AS totalChallenges,
+            CASE WHEN COALESCE(ucs.total_challenges,0)=0
+                     THEN 0 ELSE ROUND((ucs.success_count/ucs.total_challenges)*100) END AS successRate
         FROM challenge_coin_rank cr
                  JOIN user u ON u.id = cr.user_id
                  JOIN user_status us ON us.id = u.id
@@ -30,13 +30,13 @@
         SELECT
             u.id AS userId,
             us.nickname,
-            cr.`rank` AS rank,
-            cr.cumulative_point AS cumulativePoint,
-            cr.challenge_count AS challengeCount,
-            COALESCE(ucs.success_count, 0) AS successCount,
-            COALESCE(ucs.total_challenges, 0) AS totalChallenges,
-            CASE WHEN COALESCE(ucs.total_challenges, 0) = 0
-                     THEN 0 ELSE ROUND((ucs.success_count / ucs.total_challenges) * 100) END AS successRate
+            cr.`rank`                  AS `rank`,
+            cr.cumulative_point        AS cumulativePoint,
+            cr.challenge_count         AS challengeCount,
+            COALESCE(ucs.success_count, 0)   AS successCount,
+            COALESCE(ucs.total_challenges,0) AS totalChallenges,
+            CASE WHEN COALESCE(ucs.total_challenges,0)=0
+                     THEN 0 ELSE ROUND((ucs.success_count/ucs.total_challenges)*100) END AS successRate
         FROM challenge_coin_rank cr
                  JOIN user u ON u.id = cr.user_id
                  JOIN user_status us ON us.id = u.id
@@ -51,9 +51,9 @@
         VALUES (#{userId}, #{month}, #{cumulativePoint}, #{challengeCount}, #{rank}, NOW())
             ON DUPLICATE KEY UPDATE
                                  cumulative_point = VALUES(cumulative_point),
-                                 challenge_count   = VALUES(challenge_count),
-                                 `rank`            = VALUES(`rank`),
-                                 updated_at        = NOW()
+                                 challenge_count  = VALUES(challenge_count),
+                                 `rank`           = VALUES(`rank`),
+                                 updated_at       = NOW()
     </insert>
 
     <!-- (B) 현재 달 산정 대상 (참고용) -->
@@ -65,7 +65,7 @@
 
     <!-- (A) 스냅샷 Top5 + 내 랭킹 -->
     <select id="getCoinRankSnapshotTop5WithMyRank" resultType="org.scoula.challenge.rank.dto.ChallengeCoinRankSnapshotResponseDTO">
-        SELECT cr.id, u.id AS userId, us.nickname, cr.`rank`, cr.cumulative_point AS totalCoin, cr.month
+        SELECT cr.id, u.id AS userId, us.nickname, cr.`rank` AS `rank`, cr.cumulative_point AS totalCoin, cr.month
         FROM (
                  SELECT * FROM challenge_coin_rank_snapshot
                  WHERE month = #{month}
@@ -74,10 +74,8 @@
              ) cr
                  JOIN user u ON cr.user_id = u.id
                  JOIN user_status us ON u.id = us.id
-
         UNION ALL
-
-        SELECT cr.id, u.id AS userId, us.nickname, cr.`rank`, cr.cumulative_point AS totalCoin, cr.month
+        SELECT cr.id, u.id AS userId, us.nickname, cr.`rank` AS `rank`, cr.cumulative_point AS totalCoin, cr.month
         FROM challenge_coin_rank_snapshot cr
                  JOIN user u ON cr.user_id = u.id
                  JOIN user_status us ON u.id = us.id
@@ -100,7 +98,7 @@
         ON DUPLICATE KEY UPDATE
                              `rank`           = VALUES(`rank`),
                              cumulative_point = VALUES(cumulative_point),
-                             challenge_count  = VALUES(challenge_count)
+                             challenge_count  = VALUES(challenge_count);
     </insert>
 
     <!-- (C) 요약 재계산 (전 유저) -->
@@ -165,29 +163,27 @@
     <insert id="upsertRankRowForUserCurrentMonth">
         INSERT INTO challenge_coin_rank (user_id, month, cumulative_point, challenge_count, `rank`, updated_at)
         SELECT
-            u.id                               AS user_id,
-            #{month}                           AS month,
-            c.monthly_cumulative_amount        AS cumulative_point,
-            COALESCE(ucs.total_challenges, 0)  AS challenge_count,
-            0                                  AS `rank`,  -- 임시값, 아래 refreshRanksForMonth에서 재계산
-            NOW()
+            u.id AS user_id,
+            #{month} AS month,
+        c.monthly_cumulative_amount AS cumulative_point,
+        COALESCE(ucs.total_challenges, 0) AS challenge_count,
+        0 AS `rank`,
+        NOW()
         FROM coin c
             JOIN user u ON u.id = c.id
             LEFT JOIN user_challenge_summary ucs ON ucs.id = u.id
         WHERE c.id = #{userId}
         ON DUPLICATE KEY UPDATE
                              cumulative_point = VALUES(cumulative_point),
-                             challenge_count   = VALUES(challenge_count),
-                             updated_at        = NOW()
+                             challenge_count  = VALUES(challenge_count),
+                             updated_at       = NOW()
     </insert>
 
     <!-- 이벤트 기반: 당월 전체 rank 재계산 (MySQL 8+ 윈도우 함수 사용) -->
     <update id="refreshRanksForMonth">
         UPDATE challenge_coin_rank cr
             JOIN (
-            SELECT
-            user_id,
-            month,
+            SELECT user_id, month,
             DENSE_RANK() OVER (ORDER BY cumulative_point DESC, challenge_count DESC) AS new_rank
             FROM challenge_coin_rank
             WHERE month = #{month}

--- a/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeRankMapper.xml
+++ b/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeRankMapper.xml
@@ -9,10 +9,10 @@
     <select id="getCurrentChallengeRanks"
             resultType="org.scoula.challenge.rank.dto.ChallengeRankResponseDTO">
         SELECT
-            u.id                              AS userId,
-            COALESCE(us.nickname, u.nickname) AS nickname,
-            cr.`rank`                         AS rank,
-            uc.actual_value                   AS actualValue
+            u.id                               AS userId,
+            COALESCE(us.nickname, u.nickname)  AS nickname,
+            cr.`rank`                          AS `rank`,
+            uc.actual_value                    AS actualValue
         FROM challenge_rank cr
                  JOIN user_challenge uc ON uc.id = cr.user_challenge_id
                  JOIN user u            ON u.id = uc.user_id
@@ -39,12 +39,12 @@
     <select id="getChallengeRankSnapshots"
             resultType="org.scoula.challenge.rank.dto.ChallengeRankSnapshotResponseDTO">
         SELECT
-            u.id                              AS userId,
-            COALESCE(us.nickname, u.nickname) AS nickname,
-            crs.`rank`                        AS rank,
-            crs.actual_value                  AS actualValue,
-            crs.month                         AS month,
-            crs.is_checked                    AS isChecked
+            u.id                               AS userId,
+            COALESCE(us.nickname, u.nickname)  AS nickname,
+            crs.`rank`                         AS `rank`,
+            crs.actual_value                   AS actualValue,
+            crs.month                          AS month,
+        crs.is_checked                     AS isChecked
         FROM challenge_rank_snapshot crs
             JOIN user_challenge uc ON crs.user_challenge_id = uc.id
             JOIN user u            ON u.id = uc.user_id
@@ -52,6 +52,7 @@
         WHERE crs.month = #{month}
         ORDER BY crs.`rank` ASC
     </select>
+
 
     <!-- 스냅샷 저장 -->
     <insert id="insertChallengeRankSnapshot">
@@ -94,12 +95,12 @@
 
     <!-- UPSERT: 삭제 없이 최신화 -->
     <insert id="upsertChallengeRank">
-        INSERT INTO challenge_rank (user_challenge_id, `rank`, actual_value, updated_at)
+        INSERT INTO challenge_rank (`user_challenge_id`, `rank`, `actual_value`, `updated_at`)
         VALUES (#{userChallengeId}, #{rank}, #{actualValue}, NOW())
             ON DUPLICATE KEY UPDATE
-                                 `rank`       = VALUES(`rank`),
-                                 actual_value = VALUES(actual_value),
-                                 updated_at   = NOW()
+                                 `rank`        = VALUES(`rank`),
+                                 `actual_value`= VALUES(`actual_value`),
+                                 `updated_at`  = NOW()
     </insert>
 
     <!-- 계산에서 빠진 기존 행 정리 -->


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약

* MySQL 예약어 `rank` 충돌로 발생한 공통 챌린지 랭킹 조회 SQL 오류 수정
* 코인/공통 랭킹 Mapper 전반에 `rank` 컬럼·별칭 백틱(\`) 처리

## 📖 작업 내용

* **ChallengeRankMapper.xml**

  * `SELECT`/`ORDER BY`에서 `cr.\`rank\``및`AS \`rank\`\`로 통일
  * `upsertChallengeRank`에서 `rank`, `actual_value` 모두 백틱 처리
* **ChallengeCoinRankMapper.xml**

  * Top5/내 랭킹/스냅샷/재계산 모든 쿼리의 `rank` 참조를 백틱 처리
* (가이드) 운영 DB에 `challenge_rank.actual_value` 미존재 시 컬럼 추가 안내 포함

## ✅ 체크리스트

* [x] 공통 랭킹 API 200 응답 + 데이터 정상
* [x] 로그에 `near 'rank'` 오류 재현 안 됨
* [x] FE 변경 불필요 (기존 필드 그대로 사용)
* [x] (선택) `challenge_rank.actual_value` 컬럼 존재 확인

## ✋ 질문 사항

* 운영 DB에 아래 마이그레이션 적용해도 될까요?

  ```sql
  ALTER TABLE challenge_rank
      ADD COLUMN actual_value INT NOT NULL DEFAULT 0 AFTER `rank`;
  -- 필요 시 레거시 컬럼 정리
  -- ALTER TABLE challenge_rank DROP COLUMN progress_rate;
  ```

## 🔗 관련 이슈

* closes #242 

## 🚀 재배포

* 서버 재시작으로 Mapper XML 반영
* `/api/challenge/{id}/rank` 스모크 테스트
* 프론트 공통 랭킹 탭 진입/새로고침 동작 확인
