### PR TITLE
fix: challenge rank nickname error

### DIFF
--- a/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeRankMapper.xml
+++ b/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeRankMapper.xml
@@ -10,7 +10,7 @@
             resultType="org.scoula.challenge.rank.dto.ChallengeRankResponseDTO">
         SELECT
             u.id                               AS userId,
-            COALESCE(us.nickname, u.nickname)  AS nickname,
+            IFNULL(us.nickname, CONCAT('user#', u.id)) AS nickname,
             cr.`rank`                          AS `rank`,
             uc.actual_value                    AS actualValue
         FROM challenge_rank cr
@@ -39,12 +39,12 @@
     <select id="getChallengeRankSnapshots"
             resultType="org.scoula.challenge.rank.dto.ChallengeRankSnapshotResponseDTO">
         SELECT
-            u.id                               AS userId,
-            COALESCE(us.nickname, u.nickname)  AS nickname,
-            crs.`rank`                         AS `rank`,
-            crs.actual_value                   AS actualValue,
-            crs.month                          AS month,
-        crs.is_checked                     AS isChecked
+            u.id                                         AS userId,
+            IFNULL(us.nickname, CONCAT('user#', u.id))   AS nickname,
+            crs.`rank`                                   AS `rank`,
+            crs.actual_value                             AS actualValue,
+            crs.month                                    AS month,
+            crs.is_checked                               AS isChecked
         FROM challenge_rank_snapshot crs
             JOIN user_challenge uc ON crs.user_challenge_id = uc.id
             JOIN user u            ON u.id = uc.user_id


### PR DESCRIPTION
# 📌 Pull Request — 공통 랭킹 쿼리 닉네임 참조 오류 수정

## 👀 작업 요약

* `user.nickname` 컬럼 참조로 발생한 SQL 오류 수정
* 닉네임은 `user_status.nickname`만 사용하도록 정리

## 📖 작업 내용

* `ChallengeRankMapper.xml`

  * `getCurrentChallengeRanks`:

    * `COALESCE(us.nickname, u.nickname)` → **`IFNULL(us.nickname, CONCAT('user#', u.id))`**
    * ``cr.`rank` AS `rank` ``로 백틱 유지
  * `getChallengeRankSnapshots`:

    * 동일하게 **`IFNULL(us.nickname, CONCAT('user#', u.id))`** 사용
    * ``crs.`rank` AS `rank` ``로 백틱 유지
* 기타: `u.nickname` 참조 제거 (DB에 해당 컬럼 없음)

## ✅ 체크리스트

* [x] 도커 로그 `Unknown column 'u.nickname'` 재현 사라짐
* [x] `/challenge/{id}/rank` 정상 조회
* [x] 스냅샷 조회 정상 (`/challenge/ranks/snapshot?month=YYYY-MM`)
* [x] 프론트(핀니아 닉네임)와 호환 문제 없음

## 🔗 관련 이슈

* closes #244 
