### PR TITLE
fix: challenge point rank, user role add

### DIFF
--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -74,7 +74,6 @@ import javax.sql.DataSource;
         "org.scoula.agree.service",
         "org.scoula.challenge.rank.scheduler",
         "org.scoula.challenge.rank.service",
-        "org.scoula.challenge.rank.util",
         "org.scoula.common.aop",
         "org.scoula.summary.service",
         "org.scoula.coin.service"

--- a/src/main/java/org/scoula/security/account/domain/CustomUserDetails.java
+++ b/src/main/java/org/scoula/security/account/domain/CustomUserDetails.java
@@ -20,7 +20,8 @@ public class CustomUserDetails implements UserDetails {
     // 권한이 여러 개인 경우 확장 가능
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(() -> "ROLE_USER");
+        String roleName = (user.getRole() != null) ? user.getRole().name() : "USER";
+        return Collections.singleton(() -> "ROLE_" + roleName);
     }
 
     @Override

--- a/src/main/java/org/scoula/user/controller/UserController.java
+++ b/src/main/java/org/scoula/user/controller/UserController.java
@@ -10,6 +10,10 @@ import org.scoula.user.dto.*;
 import org.scoula.user.service.UserService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -74,6 +78,18 @@ public class UserController {
     public CommonResponseDTO<Boolean> isPinCreated (@AuthenticationPrincipal CustomUserDetails userDetails) {
         Boolean isPin=userService.isPin(userDetails.getUserId());
         return CommonResponseDTO.success("간편비밀번호 설정여부 조회가 완료되었습니다.",isPin);
+    }
+
+    @GetMapping("/me")
+    public CommonResponseDTO<Map<String, Object>> me(@AuthenticationPrincipal CustomUserDetails p) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("id", p.getUserId());
+        body.put("email", p.getUsername());
+        body.put("role", p.getUser().getRole() != null ? p.getUser().getRole().name() : "USER");
+        body.put("authorities", p.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toArray(String[]::new));
+        return CommonResponseDTO.success("ok", body);
     }
 
 

--- a/src/main/java/org/scoula/user/domain/User.java
+++ b/src/main/java/org/scoula/user/domain/User.java
@@ -1,6 +1,7 @@
 package org.scoula.user.domain;
 
 import lombok.Data;
+import org.scoula.user.enums.UserRole;
 
 import java.time.LocalDateTime;
 
@@ -19,4 +20,5 @@ public class User {
     private Boolean isVerified;
     private Boolean isActive;
     private String authPw;
+    private UserRole role;
 }

--- a/src/main/java/org/scoula/user/enums/UserRole.java
+++ b/src/main/java/org/scoula/user/enums/UserRole.java
@@ -1,0 +1,5 @@
+package org.scoula.user.enums;
+
+public enum UserRole {
+    USER, ADMIN
+}

--- a/src/main/java/org/scoula/user/service/UserServiceImpl.java
+++ b/src/main/java/org/scoula/user/service/UserServiceImpl.java
@@ -77,6 +77,7 @@ public class UserServiceImpl implements UserService {
         user.setUpdatedAt(LocalDateTime.now());
         user.setIsVerified(false); // default 값 (인증 미완료)
         user.setLastPwChangeAt(LocalDateTime.now());
+        user.setRole(org.scoula.user.enums.UserRole.USER); // ← 기본 USER
 
         try {
             userMapper.save(user); // 1. 유저 저장

--- a/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeRankMapper.xml
+++ b/src/main/resources/org/scoula/challenge/rank/mapper/ChallengeRankMapper.xml
@@ -5,19 +5,21 @@
 
 <mapper namespace="org.scoula.challenge.rank.mapper.ChallengeRankMapper">
 
-    <!-- 현재 랭킹 조회 -->
+    <!-- 현재 랭킹 조회 (관리자/생성자 제외) -->
     <select id="getCurrentChallengeRanks"
             resultType="org.scoula.challenge.rank.dto.ChallengeRankResponseDTO">
         SELECT
-            u.id                               AS userId,
-            IFNULL(us.nickname, CONCAT('user#', u.id)) AS nickname,
-            cr.`rank`                          AS `rank`,
-            uc.actual_value                    AS actualValue
+        u.id                                        AS userId,
+        IFNULL(us.nickname, CONCAT('user#', u.id))  AS nickname,
+        cr.`rank`                                   AS `rank`,
+        uc.actual_value                             AS actualValue
         FROM challenge_rank cr
-                 JOIN user_challenge uc ON uc.id = cr.user_challenge_id
-                 JOIN user u            ON u.id = uc.user_id
-                 LEFT JOIN user_status us ON us.id = u.id
+        JOIN user_challenge uc ON uc.id = cr.user_challenge_id
+        JOIN user u            ON u.id = uc.user_id
+        LEFT JOIN user_status us ON us.id = u.id
         WHERE uc.challenge_id = #{challengeId}
+        AND uc.is_creator = 0
+        AND (u.role IS NULL OR u.role != 'ADMIN')
         ORDER BY cr.`rank` ASC
     </select>
 
@@ -35,24 +37,25 @@
         VALUES (#{userChallengeId}, #{rank}, #{actualValue}, NOW())
     </insert>
 
-    <!-- 스냅샷 읽기 -->
+    <!-- 스냅샷 읽기 (관리자/생성자 제외) -->
     <select id="getChallengeRankSnapshots"
             resultType="org.scoula.challenge.rank.dto.ChallengeRankSnapshotResponseDTO">
         SELECT
-            u.id                                         AS userId,
-            IFNULL(us.nickname, CONCAT('user#', u.id))   AS nickname,
-            crs.`rank`                                   AS `rank`,
-            crs.actual_value                             AS actualValue,
-            crs.month                                    AS month,
-            crs.is_checked                               AS isChecked
+        u.id                                        AS userId,
+        IFNULL(us.nickname, CONCAT('user#', u.id))  AS nickname,
+        crs.`rank`                                  AS `rank`,
+        crs.actual_value                            AS actualValue,
+        crs.month                                   AS month,
+        crs.is_checked                              AS isChecked
         FROM challenge_rank_snapshot crs
-            JOIN user_challenge uc ON crs.user_challenge_id = uc.id
-            JOIN user u            ON u.id = uc.user_id
-            LEFT JOIN user_status us ON us.id = u.id
+        JOIN user_challenge uc ON crs.user_challenge_id = uc.id
+        JOIN user u            ON u.id = uc.user_id
+        LEFT JOIN user_status us ON us.id = u.id
         WHERE crs.month = #{month}
+        AND uc.is_creator = 0
+        AND (u.role IS NULL OR u.role != 'ADMIN')
         ORDER BY crs.`rank` ASC
     </select>
-
 
     <!-- 스냅샷 저장 -->
     <insert id="insertChallengeRankSnapshot">
@@ -69,28 +72,36 @@
         <result property="actualValue"     column="actual_value"/>
     </resultMap>
 
+    <!-- 랭크 계산용: 실제 참가자 정렬 (관리자/생성자 제외) -->
     <select id="getParticipantsSortedByActualValue" resultMap="participantInfoMap">
         SELECT
-            uc.id           AS user_challenge_id,
-            uc.actual_value
+        uc.id           AS user_challenge_id,
+        uc.actual_value
         FROM user_challenge uc
-                 JOIN challenge c ON uc.challenge_id = c.id
+        JOIN challenge c ON uc.challenge_id = c.id
+        JOIN user u      ON u.id = uc.user_id
         WHERE c.id = #{challengeId}
-          AND c.type = 'COMMON'
+        AND c.type = 'COMMON'
+        AND uc.is_creator = 0
+        AND (u.role IS NULL OR u.role != 'ADMIN')
         ORDER BY uc.actual_value ASC,
-                 (SELECT COUNT(*) FROM user_challenge sub WHERE sub.user_id = uc.user_id) DESC
+        (SELECT COUNT(*) FROM user_challenge sub WHERE sub.user_id = uc.user_id) DESC
     </select>
 
+    <!-- 월별 랭크 계산용 (관리자/생성자 제외) -->
     <select id="getParticipantsSortedByActualValueInMonth" resultMap="participantInfoMap">
         SELECT
-            uc.id           AS user_challenge_id,
-            uc.actual_value
+        uc.id           AS user_challenge_id,
+        uc.actual_value
         FROM user_challenge uc
-                 JOIN challenge c ON uc.challenge_id = c.id
+        JOIN challenge c ON uc.challenge_id = c.id
+        JOIN user u      ON u.id = uc.user_id
         WHERE c.type = 'COMMON'
-          AND DATE_FORMAT(c.start_date, '%Y-%m') = #{month}
+        AND DATE_FORMAT(c.start_date, '%Y-%m') = #{month}
+        AND uc.is_creator = 0
+        AND (u.role IS NULL OR u.role != 'ADMIN')
         ORDER BY uc.actual_value ASC,
-                 (SELECT COUNT(*) FROM user_challenge sub WHERE sub.user_id = uc.user_id) DESC
+        (SELECT COUNT(*) FROM user_challenge sub WHERE sub.user_id = uc.user_id) DESC
     </select>
 
     <!-- UPSERT: 삭제 없이 최신화 -->
@@ -98,9 +109,9 @@
         INSERT INTO challenge_rank (`user_challenge_id`, `rank`, `actual_value`, `updated_at`)
         VALUES (#{userChallengeId}, #{rank}, #{actualValue}, NOW())
             ON DUPLICATE KEY UPDATE
-                                 `rank`        = VALUES(`rank`),
-                                 `actual_value`= VALUES(`actual_value`),
-                                 `updated_at`  = NOW()
+                                 `rank`         = VALUES(`rank`),
+                                 `actual_value` = VALUES(`actual_value`),
+                                 `updated_at`   = NOW()
     </insert>
 
     <!-- 계산에서 빠진 기존 행 정리 -->

--- a/src/main/resources/org/scoula/user/mapper/UserMapper.xml
+++ b/src/main/resources/org/scoula/user/mapper/UserMapper.xml
@@ -11,7 +11,7 @@
 
     <insert id="save" parameterType="org.scoula.user.domain.User"
             useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO user (email, password) VALUES (#{email}, #{password})
+        INSERT INTO user (email, password, role) VALUES (#{email}, #{password}, #{role})
     </insert>
 
     <select id="findByEmail" resultType="org.scoula.user.domain.User">


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약

* **\[#246] 유저 권한(Role) 도입**: `user` 테이블에 `role` 컬럼 추가 및 Spring Security 연계.
* **\[#247] 월별 누적 포인트 랭킹(코인 랭킹) 구축**: 스케줄러/이벤트/수동 트리거 기반의 랭킹 산정 파이프라인 추가, API/매퍼/서비스/보안 설정 일괄 반영.

---

## 📖 작업 내용

### 1) \[#246] 유저 권한(Role) 추가

* **DB 마이그레이션**

  ```sql
  -- 1) role 컬럼 추가 (기본 USER)
  ALTER TABLE `user`
    ADD COLUMN `role` VARCHAR(20) NOT NULL DEFAULT 'ROLE_USER' AFTER `gender`;

  -- 2) 기존 사용자 기본값 보정
  UPDATE `user` SET `role` = 'ROLE_USER' WHERE `role` IS NULL OR `role` = '';

  -- (선택) 관리자 지정
  -- UPDATE `user` SET `role` = 'ROLE_ADMIN' WHERE email IN ('admin@example.com');
  ```
* **Security 연계**

  * `CustomUserDetails`에서 `role` → `GrantedAuthority` 매핑 확인/보정 (`ROLE_USER`/`ROLE_ADMIN`).
  * 운영 시 특정 관리 엔드포인트는 `hasRole("ADMIN")`로 전환 가능.

### 2) \[#247] 월별 누적 포인트(코인) 랭킹

* **DB 스키마** (이미 운영 DB에 존재 시 스킵)

  ```sql
  CREATE TABLE IF NOT EXISTS `challenge_coin_rank` (
    `id` BIGINT NOT NULL AUTO_INCREMENT,
    `user_id` BIGINT NOT NULL,
    `month` VARCHAR(7) NOT NULL COMMENT 'YYYY-MM',
    `rank` INT NOT NULL,
    `cumulative_point` BIGINT NOT NULL,
    `challenge_count` INT NOT NULL,
    `updated_at` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
    PRIMARY KEY (`id`),
    UNIQUE KEY `uniq_user_month` (`user_id`,`month`),
    CONSTRAINT `challenge_coin_rank_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

  CREATE TABLE IF NOT EXISTS `challenge_coin_rank_snapshot` (
    `id` BIGINT NOT NULL AUTO_INCREMENT,
    `user_id` BIGINT NOT NULL,
    `month` VARCHAR(7) NOT NULL COMMENT 'YYYY-MM',
    `rank` INT NOT NULL,
    `cumulative_point` BIGINT NOT NULL,
    `challenge_count` INT NOT NULL,
    `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,
    `is_checked` TINYINT(1) NOT NULL DEFAULT '0',
    PRIMARY KEY (`id`),
    UNIQUE KEY `uniq_user_month` (`user_id`,`month`),
    CONSTRAINT `challenge_coin_rank_snapshot_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
  ```
* **핵심 로직**

  * **산정 기준**: `coin.monthly_cumulative_amount > 0` 유저만 후보.
  * **정렬/순위**: `cumulativePoint DESC → challengeCount DESC` (공동 순위는 동일 rank).
  * **이벤트 기반**: `coinService.addCoinIncludingMonthly()` 호출 시 `CoinChangedEvent(monthlyAffected=true)` → `ChallengeCoinRankUpdateListener`가 해당 유저 행 upsert 및 월 전체 재랭킹.
  * **스케줄러** (`ChallengeCoinRankScheduler`)

    * 매일 **05:00**: 현재 달 랭킹 산정
    * 매월 1일 **05:01**: `coin.monthly_cumulative_amount` 리셋
    * 매월 1일 **05:05**: 지난달 스냅샷 저장
* **API**

  * `GET  /api/challenge/rank/coin?userId={id}` → Top5 + (내 랭킹 미포함 시 덧붙임)
  * `GET  /api/challenge/rank/coin/snapshot?month=YYYY-MM&userId={id}` → 지난달 스냅샷 Top5 + 내 랭킹
  * `PATCH /api/challenge/rank/coin/snapshot/check?month=YYYY-MM&userId={id}` → 스냅샷 확인 처리
  * `POST /api/challenge/rank/test/coin/calc` → **수동 산정 트리거**(프론트 새로고침 버튼에서 사용)
* **매퍼/서비스**

  * `ChallengeCoinRankMapper.xml`:

    * **주의**: 예약어 컬럼은 항상 **\`rank\`** 로 백틱 처리.
    * Top5/내랭킹, 스냅샷 upsert, 월 전체 재랭킹, 요약 재계산 쿼리 포함.
  * `ChallengeCoinRankService(Impl)`:

    * `calculateAndSaveRanks()`, `snapshotLastMonthRanks()`, `getTop5WithMyRank()`, 등.
  * `CoinService(Impl)`:

    * `addCoinIncludingMonthly()`/`addCoinExceptMonthly()`/`subtractCoin()` 이벤트 발행 경로 정리.
* **보안/설정**

  * `SecurityConfig`

    * `@EnableScheduling` 활성화
    * `@MapperScan` 확장: `org.scoula.coin.mapper`, `org.scoula.challenge.rank.mapper`
    * 권한:

      * `/api/challenge/rank/coin/**` → **인증 필요**
      * `POST /api/challenge/rank/test/coin/calc` → **인증 필요** (운영 시 `hasRole("ADMIN")` 전환 권장)
* **테스트 가이드(핵심)**

  1. `coin`에 해당 유저 row 존재 + `monthly_cumulative_amount > 0`로 셋(보상 시나리오 또는 임시 UPDATE).
  2. 프론트 “누적 포인트” 탭 → **새로고침 버튼** → `calc` 트리거 + 재조회.
  3. `rank <= 5` Top 영역, 내 랭킹 카드 정상 노출 확인.

---

## ✅ 체크리스트

* [x] 커밋 컨벤션 준수
* [x] 로컬/개발 환경에서 스케줄러 & 이벤트 & 수동 트리거 동작 확인
* [x] `/api/challenge/rank/coin/**` 인증 요구 확인
* [x] `rank` 컬럼 **백틱 처리** 확인(Mapper XML 전역)
* [x] 매퍼 스캔/스케줄링 활성화 적용
* [x] 기존 사용자 `role` 기본값(`ROLE_USER`) 마이그레이션 반영
* [x] 문서화(엔드포인트/스케줄/이벤트 플로우) 업데이트

---

## ✋ 질문 사항

1. `POST /api/challenge/rank/test/coin/calc` 를 운영에서 **ADMIN 전용**으로 전환해도 될까요? (프론트는 재조회만 하도록 유지)
2. 현재 `role`은 문자열(`ROLE_USER`/`ROLE_ADMIN`)로 관리합니다. **Enum 컬럼**으로 고정할지, 문자열 유지할지 결정 필요합니다.
3. 월초 리셋/스냅샷 **시간대(05:01/05:05 KST)** 가 운영 배치와 충돌 없는지 확인 부탁드립니다.

---

## 🔗 관련 이슈

* closes **#246** — 유저 테이블 권한(Role) 추가 및 보안 연계
* closes **#247** — 월별 누적 포인트 랭킹(코인 랭킹) 구축 (스케줄러/이벤트/트리거 + API)
