### PR TITLE
fix: MonthReportPdfGenerator 에 들어가는 dto 파일 수정

### DIFF
--- a/src/main/java/org/scoula/monthreport/dto/MonthReportDetailDto.java
+++ b/src/main/java/org/scoula/monthreport/dto/MonthReportDetailDto.java
@@ -14,7 +14,18 @@ import java.util.List;
 @AllArgsConstructor
 public class MonthReportDetailDto {
     private String month;
+
+    /** 이번 달 총 지출 */
     private BigDecimal totalExpense;
+
+    /** 지난 달 총 지출(없으면 0으로 간주) */
+    private BigDecimal lastMonthExpense;
+
+    /**
+     * 비교 금액 오버라이드가 필요할 때 사용하는 선택 필드.
+     * 값이 있으면 getCompareExpense()가 이 값을 그대로 반환.
+     */
+    private BigDecimal compareExpenseOverride; // 새로 추가 사항
 
     private List<MonthExpenseDto> sixMonthChart;
     private List<CategoryRatioDto> categoryChart;
@@ -22,11 +33,22 @@ public class MonthReportDetailDto {
 
     private org.scoula.monthreport.dto.AverageComparisonDto averageComparison;
 
-    private List<SpendingPatternDto> spendingPatterns; // <--- 복수 패턴 + desc
+    private List<SpendingPatternDto> spendingPatterns; // 복수 패턴
     private String spendingPatternFeedback;
 
     private String nextGoal;
     private List<RecommendedChallengeDto> recommendedChallenges;
+
+    // 새로 추가 사항
+    /**
+     * 지난달 대비 증감 금액을 반환.
+     * - compareExpenseOverride가 있으면 그 값을 그대로 씀
+     * - 아니면 totalExpense - lastMonthExpense (널은 0으로 처리)
+     */
+    public BigDecimal getCompareExpense() {
+        if (compareExpenseOverride != null) return compareExpenseOverride;
+        BigDecimal thisExp = totalExpense != null ? totalExpense : BigDecimal.ZERO;
+        BigDecimal lastExp = lastMonthExpense != null ? lastMonthExpense : BigDecimal.ZERO;
+        return thisExp.subtract(lastExp);
+    }
 }
-
-


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

배포 실패 : 아래 파일에서 컴파일 오류 발생
MonthReportPdfGenerator 에 들어가는 dto 파일 수정

## 📖 작업 내용 

### 임시 수정 내용
아래 코드를 추가
```
/**
     * 비교 금액 오버라이드가 필요할 때 사용하는 선택 필드.
     * 값이 있으면 getCompareExpense()가 이 값을 그대로 반환.
     */
    private BigDecimal compareExpenseOverride; 

...

// 새로 추가 사항
    /**
     * 지난달 대비 증감 금액을 반환.
     * - compareExpenseOverride가 있으면 그 값을 그대로 씀
     * - 아니면 totalExpense - lastMonthExpense (널은 0으로 처리)
     */
    public BigDecimal getCompareExpense() {
        if (compareExpenseOverride != null) return compareExpenseOverride;
        BigDecimal thisExp = totalExpense != null ? totalExpense : BigDecimal.ZERO;
        BigDecimal lastExp = lastMonthExpense != null ? lastMonthExpense : BigDecimal.ZERO;
        return thisExp.subtract(lastExp);
    }

```


## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- 관련된 이슈 번호를 연결해주세요. (예: closes #1234)
