### PR TITLE
fix(report): 카테고리 정규화/필터링 통일, 패턴 분류 보정, 평균비교/추천 로직 안정화

### DIFF
--- a/src/main/java/org/scoula/account/util/BankCatalog.java
+++ b/src/main/java/org/scoula/account/util/BankCatalog.java
@@ -1,0 +1,64 @@
+package org.scoula.account.util;
+
+import java.util.*;
+
+public final class BankCatalog {
+    public static final class Bank {
+        public final String code, name;
+        public final String[] demand, saving, cardCredit, cardDebit, bins;
+        public Bank(String code, String name, String[] demand, String[] saving,
+                    String[] cardCredit, String[] cardDebit, String[] bins) {
+            this.code = code; this.name = name; this.demand = demand; this.saving = saving;
+            this.cardCredit = cardCredit; this.cardDebit = cardDebit; this.bins = bins;
+        }
+    }
+
+    public static final List<Bank> BANKS = List.of(
+            new Bank("004","KB국민은행",
+                    new String[]{"KB 주거래우대통장","KB 마이핏 통장","KB Star 통장","KB 모임통장"},
+                    new String[]{"KB 자유적금","KB 1년 정기적금","KB 청년도약적금"},
+                    new String[]{"국민 톡톡","리브메이트"},
+                    new String[]{"국민 노리체크","리브 체크"},
+                    new String[]{"7018","5311"}),
+            new Bank("088","신한은행",
+                    new String[]{"신한 주거래 통장","신한 Deep 통장","신한 플러스 통장"},
+                    new String[]{"신한 자유적금","신한 정기적금","신한 청년우대형 적금"},
+                    new String[]{"신한 Deep","Mr.Life"},
+                    new String[]{"신한 체크","S20 체크"},
+                    new String[]{"9410","4305"}),
+            new Bank("020","우리은행",
+                    new String[]{"우리 WON 통장","우리 주거래 통장"},
+                    new String[]{"우리 자유적금","우리 정기적금","우리 청년 적금"},
+                    new String[]{"카드의정석","WON 카드"},
+                    new String[]{"우리 체크","WON 체크"},
+                    new String[]{"4573","4048"}),
+            new Bank("081","하나은행",
+                    new String[]{"하나 1Q 통장","하나 주거래 통장"},
+                    new String[]{"하나 자유적금","하나 정기적금","하나 청년 적금"},
+                    new String[]{"하나 1Q","멤버스"},
+                    new String[]{"하나 체크","1Q 체크"},
+                    new String[]{"5540","4386"}),
+            new Bank("011","NH농협은행",
+                    new String[]{"NH 올원 입출금","NH 주거래 통장"},
+                    new String[]{"NH 올원 적금","NH 자유적금","NH 청년희망 적금"},
+                    new String[]{"올바른 카드"},
+                    new String[]{"올원 체크"},
+                    new String[]{"3560","5399"}),
+            new Bank("090","카카오뱅크",
+                    new String[]{"카카오 입출금","세이프박스"},
+                    new String[]{"카카오 자유적금","카카오 정기예금"},
+                    new String[]{"카카오뱅크 카드"},
+                    new String[]{"카카오뱅크 체크"},
+                    new String[]{"4704","5559"}),
+            new Bank("092","토스뱅크",
+                    new String[]{"토스통장","먼슬리통장"},
+                    new String[]{"먼슬리적금","토스 자유적금"},
+                    new String[]{"토스카드"},
+                    new String[]{"토스 체크"},
+                    new String[]{"5355","5390"})
+    );
+
+    public static Random rng(long userId, String ns){
+        return new Random(Objects.hash(userId, ns, 2025, 8)); // 유저별 고정 랜덤
+    }
+}

--- a/src/main/java/org/scoula/monthreport/dto/MonthReportDetailDto.java
+++ b/src/main/java/org/scoula/monthreport/dto/MonthReportDetailDto.java
@@ -24,6 +24,8 @@ public class MonthReportDetailDto {
 
     private org.scoula.monthreport.dto.AverageComparisonDto averageComparison;
 
+    private org.scoula.monthreport.dto.PatternBannerDto patternBanner;
+
     private List<SpendingPatternDto> spendingPatterns; // 복수 패턴
     private String spendingPatternFeedback;
 

--- a/src/main/java/org/scoula/monthreport/dto/PatternBannerDto.java
+++ b/src/main/java/org/scoula/monthreport/dto/PatternBannerDto.java
@@ -1,0 +1,23 @@
+package org.scoula.monthreport.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Data @Builder @NoArgsConstructor @AllArgsConstructor
+public class PatternBannerDto {
+    private String headline;                 // 감정적 소비형 + 외식 과다형
+    private String subtitle;                 // 다음 달엔 식비와 카페 지출을 약 15% 줄여보는 걸 추천드려요.
+
+    private String primaryCode;              // IMPULSE or FRUGAL/OVERSPENDER/...
+    private String primaryLabel;             // 감정적 소비형 등
+
+    private String secondaryCode;            // FOOD_CAFE_OVER or *_OVER
+    private String secondaryLabel;           // 외식 과다형 등
+
+    private List<String> recommendCategories; // ["식비","카페"]
+    private Integer recommendPercent;        // 10 or 15
+
+    // (선택) UI용
+    private String color;    // "#5B5BD6"
+    private String icon;     // "search"
+}

--- a/src/main/java/org/scoula/monthreport/service/PatternBannerMapper.java
+++ b/src/main/java/org/scoula/monthreport/service/PatternBannerMapper.java
@@ -1,0 +1,94 @@
+package org.scoula.monthreport.service;
+
+import org.scoula.monthreport.dto.AverageComparisonDto;
+import org.scoula.monthreport.dto.PatternBannerDto;
+import org.scoula.monthreport.enums.SpendingPatternType;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+final class PatternBannerMapper {
+
+    static PatternBannerDto toBanner(PatternClassification pc, AverageComparisonDto avg) {
+        // 1) 메인 라벨: IMPULSE 우선, 없으면 overall
+        SpendingPatternType primary = pc.getPatterns().contains(SpendingPatternType.IMPULSE)
+                ? SpendingPatternType.IMPULSE : pc.getOverall();
+
+        // 2) 보조 라벨: FOOD/Cafe 합쳐서 “외식 과다형” 우선, 없으면 첫 *_OVER
+        Set<SpendingPatternType> sub = pc.getPatterns();
+        boolean foodOver = sub.contains(SpendingPatternType.FOOD_OVER);
+        boolean cafeOver = sub.contains(SpendingPatternType.CAFE_OVER);
+
+        String secondaryCode = null, secondaryLabel = null;
+        if (foodOver || cafeOver) {
+            secondaryCode = "FOOD_CAFE_OVER";
+            secondaryLabel = "외식 과다형";
+        } else {
+            Optional<SpendingPatternType> anyOver = sub.stream()
+                    .filter(t -> t.name().endsWith("_OVER"))
+                    .findFirst();
+            if (anyOver.isPresent()) {
+                secondaryCode = anyOver.get().name();
+                secondaryLabel = anyOver.get().getLabel();
+            }
+        }
+
+        // 3) 추천 카테고리: 서브 패턴 기반 → 없으면 평균 대비 초과(+) 상위 2개
+        List<String> recCats = new ArrayList<>();
+        if (foodOver) recCats.add("식비");
+        if (cafeOver) recCats.add("카페");
+        if (sub.contains(SpendingPatternType.SHOPPING_OVER)) recCats.add("쇼핑");
+        if (sub.contains(SpendingPatternType.TRANSPORT_OVER)) recCats.add("교통");
+        if (sub.contains(SpendingPatternType.SUBSCRIPTION_OVER)) recCats.add("구독");
+
+        if (recCats.isEmpty() && avg != null && avg.byCategory != null) {
+            // kosis key -> 한글 라벨
+            Map<String, String> ko = Map.of(
+                    "food","식비","cafe","카페","shopping","쇼핑",
+                    "house","주거/통신","transport","교통","subscription","구독","mart","편의점/마트"
+            );
+            recCats = avg.byCategory.entrySet().stream()
+                    .filter(e -> e.getValue() != null && e.getValue() > 0) // 평균보다 많이 쓴 카테고리
+                    .sorted((a,b) -> Integer.compare(b.getValue(), a.getValue()))
+                    .limit(2)
+                    .map(e -> ko.getOrDefault(e.getKey(), e.getKey()))
+                    .collect(Collectors.toList());
+        }
+
+        int recPct = recCats.size() >= 2 ? 15 : (recCats.isEmpty() ? 0 : 10);
+        String catsText = joinWaGwa(recCats);
+        String subtitle = recCats.isEmpty()
+                ? "이번 달 소비는 전반적으로 안정적이에요."
+                : String.format("다음 달엔 %s 지출을 약 %d%% 줄여보는 걸 추천드려요.", catsText, recPct);
+
+        String headline = secondaryLabel == null
+                ? primary.getLabel()
+                : primary.getLabel() + " + " + secondaryLabel;
+
+        return PatternBannerDto.builder()
+                .headline(headline)
+                .subtitle(subtitle)
+                .primaryCode(primary.name())
+                .primaryLabel(primary.getLabel())
+                .secondaryCode(secondaryCode)
+                .secondaryLabel(secondaryLabel)
+                .recommendCategories(recCats)
+                .recommendPercent(recPct == 0 ? null : recPct)
+                .color("#5B5BD6")
+                .icon("search")
+                .build();
+    }
+
+    private static String joinWaGwa(List<String> items) {
+        if (items == null || items.isEmpty()) return "";
+        if (items.size() == 1) return items.get(0);
+        String a = items.get(0), b = items.get(1);
+        return a + (needsGwa(a) ? "과 " : "와 ") + b;
+    }
+    private static boolean needsGwa(String word) {
+        if (word == null || word.isEmpty()) return false;
+        char ch = word.charAt(word.length() - 1);
+        if (ch < 0xAC00 || ch > 0xD7A3) return false; // 한글 아니면 대충 '와'
+        return ((ch - 0xAC00) % 28) != 0; // 받침 있으면 '과'
+    }
+}

--- a/src/main/java/org/scoula/monthreport/util/CategoryMapper.java
+++ b/src/main/java/org/scoula/monthreport/util/CategoryMapper.java
@@ -1,0 +1,60 @@
+package org.scoula.monthreport.util;
+
+public final class CategoryMapper {
+    private CategoryMapper(){}
+
+    // DB name(영문 키) -> KOSIS 키
+    public static String toKosisKey(String name){
+        if (name == null) return "etc";
+        return switch (name.trim()) {
+            case "food"         -> "food";
+            case "cafe"         -> "cafe";
+            case "shopping"     -> "shopping";
+            case "mart"         -> "mart";
+            case "house"        -> "house";
+            case "hobby"        -> "etc";        // 취미/여가는 벤치마크엔 없으니 etc로 귀속
+            case "transport"    -> "transport";
+            case "finance"      -> "house";      // 보험 등 금융 고정비는 주거/통신에 합산
+            case "subscription" -> "subscription";
+            case "transfer"     -> "etc";        // 분석/차트에서는 보통 제외(아래 exclude 함수 참고)
+            case "etc", "uncategorized" -> "etc";
+            default -> "etc";
+        };
+    }
+
+    // 라벨(한글) 또는 애매한 문자열 -> KOSIS 키 (백업용)
+    public static String fromAny(String labelOrName){
+        if (labelOrName == null) return "etc";
+        String s = labelOrName.trim();
+        // DB 키가 그대로 들어오는 경우
+        switch (s) {
+            case "food","cafe","shopping","mart","house","hobby","transport","finance","subscription","transfer","etc","uncategorized":
+                return toKosisKey(s);
+        }
+        // 한글 라벨 추정
+        if (s.contains("식비")) return "food";
+        if (s.contains("카페") || s.contains("간식")) return "cafe";
+        if (s.contains("쇼핑") || s.contains("미용")) return "shopping";
+        if (s.contains("편의점") || s.contains("마트") || s.contains("잡화")) return "mart";
+        if (s.contains("주거") || s.contains("통신")) return "house";
+        if (s.contains("교통") || s.contains("자동차")) return "transport";
+        if (s.contains("보험") || s.contains("금융")) return "house"; // finance 라벨도 house로
+        if (s.contains("구독")) return "subscription";
+        if (s.contains("취미") || s.contains("여가")) return "etc";
+        if (s.contains("이체")) return "etc";
+        if (s.contains("없음")) return "etc";
+        return "etc";
+    }
+
+    // 차트에서 빼고 싶은 카테고리 (이체/없음)
+    public static boolean excludeOnCharts(String nameOrLabel){
+        if (nameOrLabel == null) return true;
+        String s = nameOrLabel.trim();
+        return s.equals("transfer") || s.equals("uncategorized") || s.equals("카테고리 없음");
+    }
+
+    // 분석에서 무시하고 싶은 카테고리(안전망: 이체/없음)
+    public static boolean excludeOnAnalysis(String nameOrLabel){
+        return excludeOnCharts(nameOrLabel);
+    }
+}

--- a/src/main/java/org/scoula/monthreport/util/ChallengeRecommenderEngine.java
+++ b/src/main/java/org/scoula/monthreport/util/ChallengeRecommenderEngine.java
@@ -4,110 +4,144 @@ import org.scoula.monthreport.dto.RecommendationContext;
 import org.scoula.monthreport.dto.RecommendedChallengeDto;
 import org.scoula.monthreport.enums.SpendingPatternType;
 
+import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class ChallengeRecommenderEngine {
 
-    // 기본 후보(부족할 때 채우는 안전판)
-    private static final List<RecommendedChallengeDto> DEFAULTS = List.of(
-            new RecommendedChallengeDto("식비 + 카페 지출 줄이기", "350,000원 이하로 유지해보세요."),
-            new RecommendedChallengeDto("무지출 데이 도전!", "무지출 데이 2회 이상 가져보세요."),
-            new RecommendedChallengeDto("주간 총지출 상한", "최근 3개월 평균 +10% 이내 유지")
-    );
+    private static final BigDecimal ZERO = BigDecimal.ZERO;
 
     public static List<RecommendedChallengeDto> recommend(RecommendationContext ctx) {
-        if (ctx == null) return DEFAULTS.subList(0, 2);
+        // 컨텍스트 없으면 기본 두 개
+        if (ctx == null || ctx.categoryRatios == null || ctx.categoryRatios.isEmpty()) {
+            return List.of(
+                    new RecommendedChallengeDto("총지출 10% 절감", "이번 달 대비 -10%"),
+                    new RecommendedChallengeDto("식비·카페 10% 절감", "이번 달 대비 -10%")
+            );
+        }
+
+        Map<String, BigDecimal> r = ctx.categoryRatios;                 // kosis key -> %
+        Map<String, Integer> diff = ctx.averageDiffByCat == null ? Map.of() : ctx.averageDiffByCat;
+        Set<SpendingPatternType> pats = ctx.patterns == null ? Set.of() : ctx.patterns;
+
+        // 1) Overall 필요 여부
+        boolean needOverall = ctx.overall == SpendingPatternType.OVERSPENDER
+                || sumPositive(diff) >= 40; // 또래 평균 초과(+) 총합이 크면 전체 절감 유도
 
         List<RecommendedChallengeDto> out = new ArrayList<>();
-
-        // 거시 라벨 기반
-        if (ctx.overall == SpendingPatternType.OVERSPENDER) {
-            out.add(new RecommendedChallengeDto("주간 총지출 상한", "지난 3개월 평균 +10% 이내 유지"));
-        }
-        if (ctx.overall == SpendingPatternType.FRUGAL) {
-            out.add(new RecommendedChallengeDto("저축률 35% 도전", "이번 달 저축률 +5% 올리기"));
-        }
-
-        // 행동/시간 패턴
-        if (ctx.patterns != null && ctx.patterns.contains(SpendingPatternType.IMPULSE)) {
-            out.add(new RecommendedChallengeDto("야간 결제 알림", "22~02시 결제 즉시 알림 켜기"));
-        }
-        if (ctx.patterns != null && ctx.patterns.contains(SpendingPatternType.WEEKEND)) {
-            out.add(new RecommendedChallengeDto("주말 예산 봉투", "주말 총지출 2만 원 상한"));
+        if (needOverall) {
+            int pct = (ctx.overall == SpendingPatternType.OVERSPENDER) ? 12 : 10;
+            out.add(new RecommendedChallengeDto(
+                    "총지출 " + pct + "% 절감",
+                    "이번 달 대비 -" + pct + "%"
+            ));
         }
 
-        // 카테고리 과다
-        if (ctx.patterns != null && ctx.patterns.contains(SpendingPatternType.CAFE_OVER)) {
-            out.add(new RecommendedChallengeDto("카페 주3회 이하", "평일 2회 + 주말 1회 제한"));
-        }
-        if (ctx.patterns != null && ctx.patterns.contains(SpendingPatternType.SUBSCRIPTION_OVER)) {
-            out.add(new RecommendedChallengeDto("구독 1개 정리", "지난달 미사용 구독 해지"));
-        }
-        if (ctx.patterns != null && ctx.patterns.contains(SpendingPatternType.SHOPPING_OVER)) {
-            out.add(new RecommendedChallengeDto("장바구니 24시간 룰", "결제 전 하루 뒤 다시 보기"));
-        }
+        // 2) 카테고리 그룹 점수 계산
+        // 그룹 비중(%) 합
+        Map<String, BigDecimal> gRatio = new LinkedHashMap<>();
+        gRatio.put("food_cafe", r.getOrDefault("food", ZERO).add(r.getOrDefault("cafe", ZERO)));
+        gRatio.put("shopping",  r.getOrDefault("shopping", ZERO));
+        gRatio.put("house",     r.getOrDefault("house", ZERO));        // finance는 upstream에서 house로 합산된 전제
+        gRatio.put("transport", r.getOrDefault("transport", ZERO));
+        gRatio.put("subscription", r.getOrDefault("subscription", ZERO));
+        gRatio.put("mart",      r.getOrDefault("mart", ZERO));
 
-        // 벤치마크 초과(≥ +15%)
-        if (ctx.averageDiffByCat != null) {
-            ctx.averageDiffByCat.entrySet().stream()
-                    .filter(e -> e.getValue() != null && e.getValue() >= 15)
-                    .limit(1)
-                    .forEach(e -> out.add(new RecommendedChallengeDto(
-                            e.getKey() + " 15% 절감", "또래 평균 대비 초과분 줄이기")));
-        }
+        // 그룹의 평균 대비 초과(+) 합
+        Map<String, Integer> gDiff = new HashMap<>();
+        gDiff.put("food_cafe", pos(diff.get("food")) + pos(diff.get("cafe")));
+        gDiff.put("shopping",  pos(diff.get("shopping")));
+        gDiff.put("house",     pos(diff.get("house")));
+        gDiff.put("transport", pos(diff.get("transport")));
+        gDiff.put("subscription", pos(diff.get("subscription")));
+        gDiff.put("mart",      pos(diff.get("mart")));
 
-        // ===== 중복 제거
-        Map<String, RecommendedChallengeDto> dedup = out.stream()
-                .collect(Collectors.toMap(RecommendedChallengeDto::getTitle, d -> d, (a, b) -> a, LinkedHashMap::new));
-        List<RecommendedChallengeDto> result = new ArrayList<>(dedup.values());
+        // 패턴 보너스 (있으면 가점)
+        Map<String, Integer> bonus = new HashMap<>();
+        bonus.put("food_cafe", 10 * (b(pats.contains(SpendingPatternType.FOOD_OVER)) + b(pats.contains(SpendingPatternType.CAFE_OVER))));
+        bonus.put("shopping",  10 * b(pats.contains(SpendingPatternType.SHOPPING_OVER)));
+        bonus.put("house",     10 * b(pats.contains(SpendingPatternType.HOUSE_OVER)));
+        bonus.put("transport", 10 * b(pats.contains(SpendingPatternType.TRANSPORT_OVER)));
+        bonus.put("subscription", 10 * b(pats.contains(SpendingPatternType.SUBSCRIPTION_OVER)));
+        bonus.put("mart", 0);
 
-        // ===== 최소 2개 보장: 부족하면 카테고리 비중 상위에서 1~2개 보충
-        if (result.size() < 2) {
-            pickByTopCategory(ctx, result);
-        }
-        // 여전히 2개 미만이면 DEFAULTS로 채우기
-        if (result.size() < 2) {
-            for (var d : DEFAULTS) {
-                if (result.stream().noneMatch(x -> x.getTitle().equals(d.getTitle()))) {
-                    result.add(d);
-                }
-                if (result.size() >= 2) break;
-            }
-        }
-
-        // 최종: 정확히 2개만 반환
-        return result.stream().limit(2).toList();
-    }
-
-    // 카테고리 비중 상위에서 빠르게 한 개 추천 뽑기
-    private static void pickByTopCategory(RecommendationContext ctx, List<RecommendedChallengeDto> acc) {
-        if (ctx.categoryRatios == null || ctx.categoryRatios.isEmpty()) return;
-        var sorted = ctx.categoryRatios.entrySet().stream()
-                .sorted((a, b) -> b.getValue().compareTo(a.getValue()))
-                .map(Map.Entry::getKey)
+        // 최종 점수: ratio(1.0) + over(1.5) + bonus
+        record Item(String key, double score) {}
+        List<Item> ranked = gRatio.entrySet().stream()
+                .map(e -> {
+                    String k = e.getKey();
+                    double score = e.getValue().doubleValue()          // 비중
+                            + 1.5 * gDiff.getOrDefault(k, 0)           // 평균 대비 초과(+)
+                            + bonus.getOrDefault(k, 0);                 // 패턴 보너스
+                    return new Item(k, score);
+                })
+                .sorted((a,b) -> Double.compare(b.score, a.score))
                 .toList();
 
-        for (String cat : sorted) {
-            RecommendedChallengeDto c = null;
-            switch (cat) {
-                case "shopping" -> c = new RecommendedChallengeDto("장바구니 24시간 룰", "결제 전 하루 뒤 다시 보기");
-                case "cafe"     -> c = new RecommendedChallengeDto("카페 주3회 이하", "평일 2회 + 주말 1회 제한");
-                case "food"     -> c = new RecommendedChallengeDto("식비 주간예산제", "주간 예산 상한 설정하고 지키기");
-                case "subscription" -> c = new RecommendedChallengeDto("구독 1개 정리", "지난달 미사용 구독 해지");
-                case "transport" -> c = new RecommendedChallengeDto("이동비 10% 절감", "대중교통 정기권/합승/경로 최적화");
-                default -> c = new RecommendedChallengeDto("주간 총지출 상한", "최근 3개월 평균 -10% 이내 유지");
-            }
-            String title = c.getTitle();
-            if (acc.stream().noneMatch(x -> x.getTitle().equals(title))) {
-                acc.add(c);
-            }
-            if (acc.size() >= 2) return;
+        // 3) 추천 선택: overall 있으면 카테고리 1개, 없으면 2개
+        int needCats = needOverall ? 1 : 2;
+        for (Item it : ranked) {
+            if (needCats == 0) break;
+            String k = it.key;
+            BigDecimal ratio = gRatio.getOrDefault(k, ZERO);
+            int over = gDiff.getOrDefault(k, 0);
+            int bon = bonus.getOrDefault(k, 0);
+            int cut = calcCut(ratio, over, bon); // 10/12/15%
+
+            if (cut <= 0) continue; // 의미 없는 추천 스킵
+            out.add(new RecommendedChallengeDto(
+                    displayName(k) + " " + cut + "% 절감",
+                    "이번 달 대비 -" + cut + "%"
+            ));
+            needCats--;
         }
+
+        // 4) 보정: 혹시 2개 못 채우면 기본으로 채움
+        while (out.size() < 2) {
+            out.add(new RecommendedChallengeDto("총지출 10% 절감", "이번 달 대비 -10%"));
+        }
+
+        // 끝: 정확히 2개
+        return out.stream().limit(2)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
-    // 하위호환(기존 코드 호출부 유지) — 2개 반환
+    // ===== helpers =====
+    private static int sumPositive(Map<String, Integer> m) {
+        if (m == null || m.isEmpty()) return 0;
+        int s = 0;
+        for (Integer v : m.values()) if (v != null && v > 0) s += v;
+        return s;
+    }
+    private static int pos(Integer v) { return (v == null || v < 0) ? 0 : v; }
+    private static int b(boolean v) { return v ? 1 : 0; }
+
+    private static int calcCut(BigDecimal ratioPct, int overPct, int bonus) {
+        // 세기 판단: 평균보다 많이 썼거나 비중이 큰 카테고리는 더 크게 깎자
+        if (overPct >= 30 || ratioPct.compareTo(new BigDecimal("25.0")) >= 0 || bonus >= 10) return 15;
+        if (overPct >= 15 || ratioPct.compareTo(new BigDecimal("20.0")) >= 0) return 12;
+        if (ratioPct.compareTo(new BigDecimal("8.0")) >= 0) return 10;  // 너무 작은 비중은 패스
+        return 0;
+    }
+
+    private static String displayName(String key) {
+        return switch (key) {
+            case "food_cafe"   -> "식비·카페";
+            case "shopping"    -> "쇼핑";
+            case "house"       -> "주거/통신(고정비)";
+            case "transport"   -> "교통";
+            case "subscription"-> "구독";
+            case "mart"        -> "편의·마트";
+            default            -> "기타";
+        };
+    }
+
+    // 하위호환: 옛 호출부
     public static List<RecommendedChallengeDto> recommend() {
-        return DEFAULTS.subList(0, 2);
+        return List.of(
+                new RecommendedChallengeDto("총지출 10% 절감", "이번 달 대비 -10%"),
+                new RecommendedChallengeDto("식비·카페 10% 절감", "이번 달 대비 -10%")
+        );
     }
 }

--- a/src/main/java/org/scoula/monthreport/util/SpendingAnalysisEngine.java
+++ b/src/main/java/org/scoula/monthreport/util/SpendingAnalysisEngine.java
@@ -21,43 +21,37 @@ public class SpendingAnalysisEngine {
     private static final BigDecimal WEEKEND_GAP_THRESHOLD     = BigDecimal.valueOf(20); // %p
     private static final BigDecimal SUBSCRIPTION_RATIO_THRESHOLD = BigDecimal.valueOf(15); // %
 
+    // SpendingAnalysisEngine.analyze(...) 교체
     public static List<SpendingPatternType> analyze(List<Ledger> ledgerList) {
-        if (ledgerList == null || ledgerList.isEmpty()) {
-            return List.of();
-        }
+        if (ledgerList == null || ledgerList.isEmpty()) return List.of();
 
-        // 1) EXPENSE만 분석
         List<Ledger> expenses = ledgerList.stream()
                 .filter(l -> "EXPENSE".equalsIgnoreCase(safe(l.getType())))
                 .collect(Collectors.toList());
         if (expenses.isEmpty()) return List.of();
 
-        BigDecimal total = expenses.stream()
-                .map(l -> nvl(l.getAmount()))
-                .reduce(ZERO, BigDecimal::add);
-
+        BigDecimal total = expenses.stream().map(l -> nvl(l.getAmount())).reduce(ZERO, BigDecimal::add);
         if (total.compareTo(ZERO) == 0) return List.of();
 
-        // 2) 카테고리 합계
-        Map<String, BigDecimal> byCategory = expenses.stream().collect(Collectors.groupingBy(
-                l -> safe(l.getCategory()), Collectors.reducing(ZERO, l -> nvl(l.getAmount()), BigDecimal::add)
+        // ★ 카테고리 정규화(공용 매퍼 사용)
+        Map<String, BigDecimal> byCat = expenses.stream().collect(Collectors.groupingBy(
+                l -> org.scoula.monthreport.util.CategoryMapper.toKosisKey(safe(l.getCategory())),
+                Collectors.reducing(ZERO, l -> nvl(l.getAmount()), BigDecimal::add)
         ));
 
-        BigDecimal foodCafe = byCategory.getOrDefault("food", ZERO)
-                .add(byCategory.getOrDefault("cafe", ZERO));
-        BigDecimal subscription = byCategory.getOrDefault("subscription", ZERO);
+        BigDecimal foodCafe = byCat.getOrDefault("food", ZERO).add(byCat.getOrDefault("cafe", ZERO));
+        BigDecimal subscription = byCat.getOrDefault("subscription", ZERO);
 
         BigDecimal foodCafeRatio = pct(foodCafe, total);
         BigDecimal subscriptionRatio = pct(subscription, total);
 
-        // 3) 시간/요일 패턴
+        // 시간/요일
         BigDecimal midnight = sumWhere(expenses, l -> {
-            LocalDateTime dt = l.getDate();
-            int h = dt.getHour();
+            int h = l.getDate().getHour();
             return (h >= 22 || h < 2);
         });
         BigDecimal weekend = sumWhere(expenses, l -> {
-            DayOfWeek d = l.getDate().getDayOfWeek();
+            var d = l.getDate().getDayOfWeek();
             return d == DayOfWeek.SATURDAY || d == DayOfWeek.SUNDAY;
         });
         BigDecimal weekday = total.subtract(weekend);
@@ -65,42 +59,29 @@ public class SpendingAnalysisEngine {
         BigDecimal midnightRatio = pct(midnight, total);
         BigDecimal weekendRatio  = pct(weekend, total);
         BigDecimal weekdayRatio  = pct(weekday, total);
-        BigDecimal weekendGap    = weekendRatio.subtract(weekdayRatio);
+        BigDecimal weekendGap    = weekendRatio.subtract(weekdayRatio); // %p
 
-        // 4) 패턴 판단
         List<SpendingPatternType> out = new ArrayList<>();
 
-        if (foodCafeRatio.compareTo(FOOD_CAFE_RATIO_THRESHOLD) >= 0) {
+        if (foodCafeRatio.compareTo(FOOD_CAFE_RATIO_THRESHOLD) >= 0)
             out.add(SpendingPatternType.FOOD_OVER);
-        }
 
-        boolean impulse = false;
-        if (midnightRatio.compareTo(MIDNIGHT_RATIO_THRESHOLD) >= 0) impulse = true;
-        if (weekendGap.compareTo(WEEKEND_GAP_THRESHOLD) >= 0) impulse = true;
-        if (subscriptionRatio.compareTo(SUBSCRIPTION_RATIO_THRESHOLD) >= 0) impulse = true; // 고정비 과다도 충동/방임으로 판단
+        if (subscriptionRatio.compareTo(SUBSCRIPTION_RATIO_THRESHOLD) >= 0)
+            out.add(SpendingPatternType.SUBSCRIPTION_OVER);
 
-        if (impulse) out.add(SpendingPatternType.IMPULSE);
+        if (midnightRatio.compareTo(MIDNIGHT_RATIO_THRESHOLD) >= 0)
+            out.add(SpendingPatternType.LATE_NIGHT);
+
+        if (weekendGap.compareTo(WEEKEND_GAP_THRESHOLD) >= 0)
+            out.add(SpendingPatternType.WEEKEND);
+
+        // 야간/주말 과다면 충동적 소비 추정 라벨도 추가
+        if (out.contains(SpendingPatternType.LATE_NIGHT) || out.contains(SpendingPatternType.WEEKEND))
+            out.add(SpendingPatternType.IMPULSE);
 
         return Collections.unmodifiableList(out);
     }
 
-    // 기존 시그니처 유지(백워드 호환)
-    public static String getPatternFeedback(List<SpendingPatternType> patterns) {
-        if (patterns == null || patterns.isEmpty()) {
-            return "소비 데이터가 부족합니다.";
-        }
-        boolean hasImpulse = patterns.contains(SpendingPatternType.IMPULSE);
-        boolean hasFood    = patterns.contains(SpendingPatternType.FOOD_OVER);
-
-        if (hasImpulse && hasFood) {
-            return "감정적 소비와 외식/카페 지출이 높습니다. 야간·주말 결제 제한과 식비 예산(주 단위)을 함께 설정해 보세요.";
-        } else if (hasImpulse) {
-            return "감정적 소비가 포착됩니다. 야간 결제 알림/한도와 주말 예산 상한을 설정해 보세요.";
-        } else if (hasFood) {
-            return "외식·카페 비중이 높습니다. 평일 도시락/홈카페 비율을 늘려 다음 달 식비를 15% 줄여보세요.";
-        }
-        return "이번 달 소비 패턴이 안정적입니다.";
-    }
 
     // ===== Helpers =====
     private static BigDecimal pct(BigDecimal part, BigDecimal total) {


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

## 📖 작업 내용 
항상 STABLE만 뜨는 문제, 카테고리 키 불일치, 이체/없음 포함으로 인한 비율 왜곡, 평균비교 분모 불일치를 한 번에 정리.
분석/추천 컨텍스트를 KOSIS 키(food/cafe/...) 기준으로 일원화하고, 차트는 한글 라벨 그대로 노출.
추천은 “총지출 절감 / 카테고리 절감” 두 축만 유지하면서 점수 기반으로 2개 정확히 리턴.

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈

- 관련된 이슈 번호를 연결해주세요. (예: closes #1234)
