### PR TITLE
feat: 자산 초기 목업 연동

### DIFF
--- a/src/main/java/org/scoula/account/controller/AccountController.java
+++ b/src/main/java/org/scoula/account/controller/AccountController.java
@@ -22,51 +22,44 @@ public class AccountController {
     @PostMapping("/register")
     public ResponseEntity<CommonResponseDTO<String>> registerAccount(
             @AuthenticationPrincipal CustomUserDetails user,
-            @RequestBody FinAccountRequestDto dto) {
-
+            @RequestBody(required = false) FinAccountRequestDto dto // ★ 바디 옵셔널
+    ) {
         Long userId = user.getUserId();
         AccountRegisterResponseDto responseDto = accountService.registerFinAccount(userId, dto);
-        String finAcno = responseDto.getFinAccount();
-        return ResponseEntity.ok(CommonResponseDTO.success("계좌 등록 성공 및 핀어카운트 발급 성공", finAcno));
+        return ResponseEntity.ok(
+                CommonResponseDTO.success("계좌 등록 성공 및 핀어카운트 발급 성공", responseDto.getFinAccount())
+        );
     }
 
-    // 잔액 및 거래내역 동기화
     @PostMapping("/{accountId}/sync")
     public ResponseEntity<CommonResponseDTO<Void>> syncAccountData(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long accountId) {
-
         Long userId = user.getUserId();
         accountService.syncAccountById(userId, accountId);
         return ResponseEntity.ok(CommonResponseDTO.success("계좌 동기화 성공", null));
     }
 
-    // 전체 계좌 동기화
     @PostMapping("/sync-all")
     public ResponseEntity<CommonResponseDTO<Void>> syncAllAccounts(
             @AuthenticationPrincipal CustomUserDetails user) {
-
         Long userId = user.getUserId();
         accountService.syncAllAccountsByUserId(userId);
         return ResponseEntity.ok(CommonResponseDTO.success("사용자 전체 계좌 동기화 성공", null));
     }
 
-    // 계좌 삭제 (비활성화)
     @DeleteMapping("/{accountId}")
     public ResponseEntity<CommonResponseDTO<Void>> deleteAccount(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long accountId) {
-
         Long userId = user.getUserId();
         accountService.deactivateAccount(accountId, userId);
         return ResponseEntity.ok(CommonResponseDTO.success("계좌 비활성화 완료"));
     }
 
-    // 계좌 목록 조회
     @GetMapping("/list")
     public ResponseEntity<CommonResponseDTO<AccountListWithTotalDto>> getAccountsWithTotal(
             @AuthenticationPrincipal CustomUserDetails user) {
-
         Long userId = user.getUserId();
         AccountListWithTotalDto result = accountService.getAccountsWithTotal(userId);
         return ResponseEntity.ok(CommonResponseDTO.success("계좌 목록 조회 성공", result));

--- a/src/main/java/org/scoula/account/mapper/AccountMapper.java
+++ b/src/main/java/org/scoula/account/mapper/AccountMapper.java
@@ -21,4 +21,5 @@ public interface AccountMapper {
     List<Account> findActiveByUserId(Long userId);
     List<Account> findByIdList(List<Long> ids);
     BigDecimal sumBalanceByUserId(Long userId);
+    int countByUserAndType(@Param("userId") Long userId, @Param("type") String type);
 }

--- a/src/main/java/org/scoula/card/controller/CardController.java
+++ b/src/main/java/org/scoula/card/controller/CardController.java
@@ -25,7 +25,8 @@ public class CardController {
     @PostMapping("/register")
     public ResponseEntity<CommonResponseDTO<CardRegisterResponseDto>> registerCard(
             @AuthenticationPrincipal CustomUserDetails user,
-            @RequestBody FinCardRequestDto dto) {
+            @RequestBody(required = false) FinCardRequestDto dto // ★ 바디 옵셔널
+    ) {
         Long userId = user.getUserId();
         CardRegisterResponseDto response = cardService.registerCard(userId, dto);
         return ResponseEntity.ok(CommonResponseDTO.success("카드 등록 및 승인내역 저장 완료", response));
@@ -62,7 +63,7 @@ public class CardController {
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth month) {
         Long userId = user.getUserId();
-        YearMonth targetMonth = month != null ? month : YearMonth.now();
+        YearMonth targetMonth = (month != null) ? month : YearMonth.now();
         List<CardDto> result = cardService.getCardsWithMonth(userId, targetMonth);
         return ResponseEntity.ok(CommonResponseDTO.success("카드 목록 조회 성공", result));
     }

--- a/src/main/java/org/scoula/card/mapper/CardMapper.java
+++ b/src/main/java/org/scoula/card/mapper/CardMapper.java
@@ -14,4 +14,5 @@ public interface CardMapper {
     void updateIsActive(@Param("id") Long id, @Param("isActive") boolean isActive);
     List<Card> findActiveByUserId(Long userId);
     List<Card> findByIdList(List<Long> ids);
+    int countByUser(@Param("userId") Long userId);
 }

--- a/src/main/java/org/scoula/card/service/CardServiceImpl.java
+++ b/src/main/java/org/scoula/card/service/CardServiceImpl.java
@@ -6,12 +6,12 @@ import org.json.JSONObject;
 import org.scoula.card.domain.Card;
 import org.scoula.card.dto.CardDto;
 import org.scoula.card.dto.CardRegisterResponseDto;
+import org.scoula.card.mapper.CardMapper;
 import org.scoula.common.exception.BaseException;
 import org.scoula.common.exception.ForbiddenException;
-import org.scoula.nhapi.dto.FinCardRequestDto;
-import org.scoula.card.mapper.CardMapper;
-import org.scoula.transactions.mapper.CardTransactionMapper;
 import org.scoula.nhapi.client.NHApiClient;
+import org.scoula.nhapi.dto.FinCardRequestDto;
+import org.scoula.transactions.mapper.CardTransactionMapper;
 import org.scoula.transactions.service.CardTransactionService;
 import org.springframework.stereotype.Service;
 
@@ -29,24 +29,53 @@ public class CardServiceImpl implements CardService {
     private final CardMapper cardMapper;
     private final CardTransactionMapper cardTransactionMapper;
     private final CardTransactionService cardTransactionService;
+    private final org.scoula.nhapi.util.FirstLinkOnboardingService firstLinkOnboardingService;
 
     @Override
     public CardRegisterResponseDto registerCard(Long userId, FinCardRequestDto dto) {
-        // 1. 핀카드 발급
-        JSONObject res1 = nhApiClient.callOpenFinCard(dto.getCardNumber(), dto.getBirthday());
-        log.info("📦 핀카드 발급 응답: {}", res1.toString());
 
-        if (!res1.has("Rgno")) {
-            throw new BaseException("핀카드 발급 실패: 'Rgno' 없음. 응답 = " + res1.toString(), 500);
+        // ===== ① DTO 비거나 placeholder면 → MOCK 경로
+        if (isEmptyOrPlaceholder(dto)) {
+            var brand = org.scoula.nhapi.util.CardBrandingUtil.pickForUser(userId, true); // 신용
+
+            JSONObject res1 = nhApiClient.callOpenFinCard("MOCK-" + System.nanoTime(), "19990101");
+            String rgno = res1.optString("Rgno");
+            String finCardNumber = nhApiClient.checkOpenFinCard(rgno, "19990101").optString("FinCard");
+
+            Card card = Card.builder()
+                    .userId(userId)
+                    .finCardNumber(finCardNumber)
+                    .backCode("00")
+                    .bankName(brand.bankName())
+                    .cardName(brand.cardName())
+                    .cardMaskednum(brand.masked())
+                    .cardMemberType("SELF")
+                    .cardType(brand.cardType()) // "CREDIT"
+                    .isActive(true)
+                    .build();
+            cardMapper.insertCard(card);
+
+            // 승인 더미 저장
+            cardTransactionService.syncCardTransactions(userId, card.getId(), finCardNumber, true);
+
+            // 첫 연동 패키지
+            firstLinkOnboardingService.runOnceOnFirstLink(userId);
+
+            log.info("✅ [MOCK] 카드 등록 및 승인내역 동기화 완료: {}", card);
+            return CardRegisterResponseDto.builder()
+                    .cardId(card.getId())
+                    .finCardNumber(finCardNumber)
+                    .build();
         }
 
+        // ===== ② DTO 채워져 있으면 → 정상 경로
+        JSONObject res1 = nhApiClient.callOpenFinCard(dto.getCardNumber(), dto.getBirthday());
+        log.info("📦 핀카드 발급 응답: {}", res1);
+        if (!res1.has("Rgno")) throw new BaseException("핀카드 발급 실패: 'Rgno' 없음. 응답 = " + res1, 500);
+
         String rgno = res1.getString("Rgno");
+        String finCardNumber = nhApiClient.checkOpenFinCard(rgno, dto.getBirthday()).optString("FinCard");
 
-        // 2. 핀카드 확인
-        JSONObject res2 = nhApiClient.checkOpenFinCard(rgno, dto.getBirthday());
-        String finCardNumber = res2.optString("FinCard");
-
-        // 3. 카드 DB 등록
         Card card = Card.builder()
                 .userId(userId)
                 .finCardNumber(finCardNumber)
@@ -56,14 +85,14 @@ public class CardServiceImpl implements CardService {
                 .cardMaskednum("7018-****-****-1234")
                 .cardMemberType("SELF")
                 .cardType("DEBIT")
+                .isActive(true)
                 .build();
         cardMapper.insertCard(card);
 
-        // 4. 승인내역 동기화 (초기 전체 동기화)
         cardTransactionService.syncCardTransactions(userId, card.getId(), finCardNumber, true);
+        firstLinkOnboardingService.runOnceOnFirstLink(userId);
 
         log.info("✅ 카드 등록 및 승인내역 동기화 완료: {}", card);
-
         return CardRegisterResponseDto.builder()
                 .cardId(card.getId())
                 .finCardNumber(finCardNumber)
@@ -73,23 +102,11 @@ public class CardServiceImpl implements CardService {
     @Override
     public void syncCardById(Long userId, Long cardId) {
         Card card = cardMapper.findById(cardId);
-        if (card == null) {
-            throw new BaseException("해당 카드가 존재하지 않습니다.", 404);
-        }
-        if (!card.getUserId().equals(userId)) {
-            throw new ForbiddenException("본인 카드만 동기화할 수 있습니다");
-        }
-        if (!Boolean.TRUE.equals(card.getIsActive())) {
-            throw new BaseException("비활성화된 카드입니다.", 400);
-        }
+        if (card == null) throw new BaseException("해당 카드가 존재하지 않습니다.", 404);
+        if (!card.getUserId().equals(userId)) throw new ForbiddenException("본인 카드만 동기화할 수 있습니다");
+        if (!Boolean.TRUE.equals(card.getIsActive())) throw new BaseException("비활성화된 카드입니다.", 400);
 
-        cardTransactionService.syncCardTransactions(
-                userId,
-                card.getId(),
-                card.getFinCardNumber(),
-                true
-        );
-
+        cardTransactionService.syncCardTransactions(userId, card.getId(), card.getFinCardNumber(), true);
         log.info("✅ 카드 {} 승인내역 갱신 완료", cardId);
     }
 
@@ -100,14 +117,8 @@ public class CardServiceImpl implements CardService {
             log.info("❗️ 동기화할 카드가 없습니다. userId={}", userId);
             return;
         }
-
         for (Card card : cards) {
-            cardTransactionService.syncCardTransactions(
-                    userId,
-                    card.getId(),
-                    card.getFinCardNumber(),
-                    true
-            );
+            cardTransactionService.syncCardTransactions(userId, card.getId(), card.getFinCardNumber(), true);
             log.info("✅ 카드 동기화 완료: cardId={}, userId={}", card.getId(), userId);
         }
     }
@@ -115,15 +126,8 @@ public class CardServiceImpl implements CardService {
     @Override
     public void deactivateCard(Long cardId, Long userId) {
         Card card = cardMapper.findById(cardId);
-
-        if (card == null || !card.getUserId().equals(userId)) {
-            throw new ForbiddenException("본인 카드만 삭제할 수 있습니다");
-        }
-
-        if (!Boolean.TRUE.equals(card.getIsActive())) {
-            return;
-        }
-
+        if (card == null || !card.getUserId().equals(userId)) throw new ForbiddenException("본인 카드만 삭제할 수 있습니다");
+        if (!Boolean.TRUE.equals(card.getIsActive())) return;
         cardMapper.updateIsActive(cardId, false);
     }
 
@@ -136,5 +140,20 @@ public class CardServiceImpl implements CardService {
             BigDecimal spent = cardTransactionMapper.sumMonthlySpendingByCard(userId, card.getId(), start, end);
             return CardDto.from(card, spent == null ? BigDecimal.ZERO : spent);
         }).collect(Collectors.toList());
+    }
+
+    /* ===== 헬퍼 ===== */
+    private static boolean isEmptyOrPlaceholder(FinCardRequestDto dto) {
+        return dto == null
+                || blankLike(dto.getCardNumber())
+                || blankLike(dto.getBirthday());
+    }
+    private static boolean blankLike(String s) {
+        if (s == null) return true;
+        String v = s.trim();
+        return v.isEmpty()
+                || v.equalsIgnoreCase("string")
+                || v.equalsIgnoreCase("null")
+                || v.equalsIgnoreCase("undefined");
     }
 }

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -62,6 +62,7 @@ import javax.sql.DataSource;
         "org.scoula.nhapi.service",
         "org.scoula.nhapi.client",
         "org.scoula.nhapi.parser",
+        "org.scoula.nhapi.util",
         "org.scoula.challenge.service",
         "org.scoula.challenge.scheduler",
         "org.scoula.user.util",

--- a/src/main/java/org/scoula/nhapi/parser/NhCardParser.java
+++ b/src/main/java/org/scoula/nhapi/parser/NhCardParser.java
@@ -9,15 +9,15 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 @Slf4j
 public class NhCardParser {
 
     public static List<NhCardTransactionResponseDto> parse(JSONObject response) {
+        // NH 쪽 응답은 "REC"일 수도 있어서 둘 다 대비
         JSONArray recArray = response.optJSONArray("Rec");
+        if (recArray == null) recArray = response.optJSONArray("REC");
         if (recArray == null) return List.of();
 
         List<NhCardTransactionResponseDto> list = new ArrayList<>();
@@ -25,40 +25,80 @@ public class NhCardParser {
         for (int i = 0; i < recArray.length(); i++) {
             JSONObject obj = recArray.getJSONObject(i);
 
+            // 1) 승인번호: 우선 가능한 키들 탐색, 없으면 결정적 더미 생성
+            String auth = opt(obj, "AthzNo", "AuthNo", "AuthNumber", "ApvNo");
+            if (isBlank(auth)) auth = deriveAuthFallback(obj);
+
+            // 2) 금액/일시/가맹점: 모의키까지 모두 커버
+            BigDecimal amount = parseDecimal(obj, "ApvAmt", "AthzAmt", "Amt", "ApprovedAmt");
+            LocalDateTime approvedAt = parseDateTime(opt(obj, "ApvYmdHms", "AthzDtm", "AprvDtm", "ApprovedDateTime", "AthzDateTime"));
+            LocalDate paymentDate = parseDate(opt(obj, "StlmDt", "PaymentDate", "Pymd"));
+            String merchantName = opt(obj, "MrhstNm", "MctNm", "MerchantName", "MchtNm");
+
+            // 3) 기타 필드
+            String salesType = opt(obj, "Stcd", "SalesType", "Sales_Tp");
+            boolean cancelled = parseYn(obj, "CancYn", "CnclYn", "IsCancelled");
+            BigDecimal cancelAmt = parseDecimal(obj, "CancAmt", "CancelAmount");
+            LocalDateTime cancelledAt = parseDateTime(opt(obj, "CancDtm", "CnclDtm", "CancelledDateTime"));
+
+            String tpbcd = opt(obj, "TpbCd", "Tpbcd", "Mcc");
+            String tpbcdNm = opt(obj, "TpbCdNm", "TpbcdNm", "MccNm");
+
+            String currency = opt(obj, "FgnCrcyCd", "Currency", "Ccy");
+            if (isBlank(currency)) currency = "KRW";
+
+            int instMm = obj.optInt("InstMmCnt", obj.optInt("InstallmentMonth", 0));
+
+            // ====== ✅ NOT NULL 대비 폴백들 ======
+            if (approvedAt == null) {
+                approvedAt = LocalDateTime.now();                 // ✅ approved_at 보정(컬럼이 NOT NULL일 가능성 대비)
+            }
+            if (paymentDate == null) {
+                paymentDate = approvedAt.toLocalDate().plusDays(2); // ✅ payment_date 보정(가장 중요한 라인)
+            }
+            if (isBlank(merchantName)) merchantName = "미상";        // ✅ 가맹점 이름 보정
+            if (isBlank(salesType)) salesType = "1";                 // ✅ 매출유형 기본값
+            if (tpbcdNm == null && tpbcd != null) tpbcdNm = tpbcd;   // ✅ 분류명 없으면 코드로 대체
+            // ===================================
+
             NhCardTransactionResponseDto dto = NhCardTransactionResponseDto.builder()
-                    .authNumber(opt(obj, "AthzNo", "AuthNo", "AuthNumber"))
-                    .salesType(opt(obj, "Stcd", "SalesType", "Sales_Tp"))
-                    .approvedAt(parseDateTime(opt(obj, "AthzDtm", "AprvDtm", "ApprovedDateTime", "AthzDateTime")))
-                    .paymentDate(parseDate(opt(obj, "StlmDt", "PaymentDate", "Pymd")))
-                    .amount(parseDecimal(obj, "AthzAmt", "Amt", "ApprovedAmt"))
-                    .cancelled(parseYn(obj, "CancYn", "CnclYn", "IsCancelled"))
-                    .cancelAmount(parseDecimal(obj, "CancAmt", "CancelAmount"))
-                    .cancelledAt(parseDateTime(opt(obj, "CancDtm", "CnclDtm", "CancelledDateTime")))
-                    .merchantName(opt(obj, "MctNm", "MerchantName", "MchtNm"))
-                    .tpbcd(opt(obj, "TpbCd", "Tpbcd", "Mcc"))
-                    .tpbcdNm(opt(obj, "TpbCdNm", "TpbcdNm", "MccNm"))
-                    .installmentMonth(obj.optInt("InstMmCnt", obj.optInt("InstallmentMonth", 0)))
-                    .currency(opt(obj, "FgnCrcyCd", "Currency", "Ccy", "KRW"))
+                    .authNumber(auth)
+                    .salesType(salesType)
+                    .approvedAt(approvedAt)
+                    .paymentDate(paymentDate)
+                    .amount(amount != null ? amount : BigDecimal.ZERO)
+                    .cancelled(cancelled)
+                    .cancelAmount(cancelAmt != null ? cancelAmt : BigDecimal.ZERO)
+                    .cancelledAt(cancelledAt)
+                    .merchantName(merchantName)
+                    .tpbcd(tpbcd)
+                    .tpbcdNm(tpbcdNm)
+                    .installmentMonth(instMm)
+                    .currency(currency)
                     .foreignAmount(parseDecimal(obj, "FgnAthzAmt", "ForeignAmount", "FrnAmt"))
                     .build();
 
             list.add(dto);
         }
 
-        // 시간 정렬 보장(승인일시가 없다면 그대로)
         list.sort(Comparator.comparing(NhCardTransactionResponseDto::getApprovedAt,
                 Comparator.nullsLast(Comparator.naturalOrder())));
         return list;
     }
+
 
     /* ---------- helpers ---------- */
 
     private static String opt(JSONObject o, String... keys) {
         for (String k : keys) {
             String v = o.optString(k, null);
-            if (v != null && !v.isEmpty()) return v;
+            if (v != null && !v.isBlank()) return v;
         }
         return null;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
     }
 
     private static boolean parseYn(JSONObject o, String... keys) {
@@ -83,13 +123,14 @@ public class NhCardParser {
                 log.warn("⚠️ 금액 파싱 실패 [{}]: {}", k, raw);
             }
         }
-        return BigDecimal.ZERO;
+        return null;
     }
 
     private static LocalDate parseDate(String yyyymmdd) {
         if (yyyymmdd == null || yyyymmdd.isBlank()) return null;
         try {
-            return LocalDate.parse(yyyymmdd.replaceAll("[^0-9]", ""), DateTimeFormatter.BASIC_ISO_DATE);
+            String s = yyyymmdd.replaceAll("[^0-9]", "");
+            return LocalDate.parse(s, DateTimeFormatter.BASIC_ISO_DATE);
         } catch (Exception e) {
             log.warn("⚠️ 날짜 파싱 실패(yyyyMMdd): {}", yyyymmdd);
             return null;
@@ -98,16 +139,31 @@ public class NhCardParser {
 
     private static LocalDateTime parseDateTime(String yyyymmddhhmmss) {
         if (yyyymmddhhmmss == null || yyyymmddhhmmss.isBlank()) return null;
-        String s = yyyymmddhhmmss.replaceAll("[^0-9]", ""); // 20250101T120000 → 20250101120000
+        String s = yyyymmddhhmmss.replaceAll("[^0-9]", ""); // 2025-08-13T19:12:00 → 20250813191200
         try {
-            if (s.length() == 8) s += "000000";       // yyyyMMdd → +000000
-            else if (s.length() == 10) s += "0000";   // yyyyMMddHH → +mmss
-            else if (s.length() == 12) s += "00";     // yyyyMMddHHmm → +ss
+            if (s.length() == 8) s += "000000";
+            else if (s.length() == 10) s += "0000";
+            else if (s.length() == 12) s += "00";
             else if (s.length() > 14) s = s.substring(0, 14);
             return LocalDateTime.parse(s, DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
         } catch (Exception e) {
             log.warn("⚠️ 일시 파싱 실패(yyyyMMddHHmmss): {}", yyyymmddhhmmss);
             return null;
         }
+    }
+
+    /**
+     * 승인번호가 없을 때 결정적(fixed) 더미 승인번호 생성.
+     * 같은 원본 레코드면 항상 같은 값이 나오므로 재동기화/재수집에도 중복 없이 동작.
+     */
+    private static String deriveAuthFallback(JSONObject o) {
+        String stamp = opt(o, "ApvYmdHms", "AthzDtm", "AprvDtm", "ApprovedDateTime", "AthzDateTime");
+        String amt   = opt(o, "ApvAmt", "AthzAmt", "Amt", "ApprovedAmt");
+        String merch = opt(o, "MrhstNm", "MctNm", "MerchantName", "MchtNm");
+        String seed = (stamp == null ? "" : stamp) + "|" + (amt == null ? "" : amt) + "|" + (merch == null ? "" : merch);
+        // 해시 → 양수 문자열
+        int h = seed.hashCode();
+        String suffix = Integer.toUnsignedString(h);
+        return "DUM" + suffix; // 예: DUM187a9c2b
     }
 }

--- a/src/main/java/org/scoula/nhapi/service/NhAccountServiceImpl.java
+++ b/src/main/java/org/scoula/nhapi/service/NhAccountServiceImpl.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.scoula.account.domain.Account;
+import org.scoula.account.mapper.AccountMapper;
 import org.scoula.nhapi.client.NHApiClient;
 import org.scoula.nhapi.dto.FinAccountRequestDto;
 import org.scoula.nhapi.dto.NhAccountTransactionResponseDto;
@@ -22,6 +24,7 @@ import java.util.*;
 public class NhAccountServiceImpl implements NhAccountService {
 
     private final NHApiClient nhApiClient;
+    private final AccountMapper accountMapper; // ★ 추가
 
     @Override
     public String callOpenFinAccount(FinAccountRequestDto dto) {
@@ -62,18 +65,32 @@ public class NhAccountServiceImpl implements NhAccountService {
     public List<NhAccountTransactionResponseDto> callTransactionList(
             Long userId, Long accountId, String finAcno, String from, String to
     ) {
+        // ★ 계좌 타입 조회
+        Account acc = accountMapper.findById(accountId);
+        String accType = (acc != null && acc.getAccountType() != null) ? acc.getAccountType() : "DEPOSIT";
+        if (!"DEPOSIT".equalsIgnoreCase(accType)) {
+            log.info("↩️ {} 계좌 거래 스킵 (accountId={})", accType, accountId);
+            return java.util.Collections.emptyList();
+        }
+
         JSONObject res = nhApiClient.callTransactionList(finAcno, from, to);
         String rpcd = res.getJSONObject("Header").getString("Rpcd");
 
+        // NH가 "거래없음"을 줬을 때
         if ("A0090".equals(rpcd)) {
-            log.info("✅ 거래내역 없음 → 더미 생성 (finAcno: {}, 기간: {}~{})", finAcno, from, to);
+            log.info("✅ 거래내역 없음 (finAcno: {}, 기간: {}~{}, type={})", finAcno, from, to, accType);
+            // ★ SAVING/INVEST는 더미 생성 금지
+            if (!"DEPOSIT".equalsIgnoreCase(accType)) return Collections.emptyList();
             return createDummyTransactions(userId, accountId, from, to);
         }
         if (!"00000".equals(rpcd)) {
             throw new NHApiException("거래내역 조회 실패: " + rpcd);
         }
 
+        // 키 대소문자 모두 대응
         JSONArray arr = res.optJSONArray("Rec");
+        if (arr == null) arr = res.optJSONArray("REC");
+
         List<NhAccountTransactionResponseDto> list = new ArrayList<>();
         if (arr != null) {
             for (int i = 0; i < arr.length(); i++) {
@@ -85,22 +102,25 @@ public class NhAccountServiceImpl implements NhAccountService {
         }
 
         if (list.isEmpty()) {
-            log.info("ℹ️ NH 응답은 성공이지만 기록 0건 → 더미 생성 (finAcno: {}, 기간: {}~{})", finAcno, from, to);
+            log.info("ℹ️ NH 성공이지만 기록 0건 (type={})", accType);
+            // ★ SAVING/INVEST는 더미 생성 금지
+            if (!"DEPOSIT".equalsIgnoreCase(accType)) return Collections.emptyList();
             return createDummyTransactions(userId, accountId, from, to);
         }
         return list;
     }
-    /* ===== 설정 ===== */
+
+    /* ===== 아래는 네 기존 더미 생성 로직: DEPOSIT에서만 사용 ===== */
+
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-    private static final int  DUMMY_MONTHS_BACK = 6;   // 최초 생성 범위
-    private static final int  MIN_DAILY = 2;
-    private static final int  MAX_DAILY = 9;
+    private static final int  DUMMY_MONTHS_BACK = 6;
+    private static final int  MIN_DAILY = 0;
+    private static final int  MAX_DAILY = 6;
     private static final int  PAYDAY = 25;
 
-    // 안전 잔액(항상 남겨둘 최소 버퍼) & 거래 한도
-    private static final BigDecimal SAFETY = bd(10_000);          // 최소 남길 돈
-    private static final BigDecimal MIN_TX = bd(2_000);           // 단건 최소
-    private static final BigDecimal MAX_TX = bd(180_000);         // 단건 최대
+    private static final BigDecimal SAFETY = bd(10_000);
+    private static final BigDecimal MIN_TX = bd(2_000);
+    private static final BigDecimal MAX_TX = bd(180_000);
     private static final BigDecimal MIN_DAILY_BUDGET = bd(20_000);
     private static final BigDecimal MAX_DAILY_BUDGET = bd(300_000);
 
@@ -123,73 +143,55 @@ public class NhAccountServiceImpl implements NhAccountService {
             new FixedBill(15,  90_000, "아파트 관리비"),
             new FixedBill(23,  19_800, "멜론 구독")
     );
-    /* ===== 더미 거래 생성 (마이너스 금지, from~to만) ===== */
+
     private List<NhAccountTransactionResponseDto> createDummyTransactions(
             Long userId, Long accountId, String from, String to
     ) {
-        // 1) 기간 결정 (to는 오늘을 넘지 않게)
         LocalDate today = LocalDate.now(KST);
         LocalDate end   = min(parseYYYYMMDD(to, today), today);
-        LocalDate start = parseYYYYMMDD(from, end.minusMonths(DUMMY_MONTHS_BACK)); // from 없으면 6개월 전
-        if (start.isAfter(end)) start = end.minusDays(7);                         // 안전 장치
+        LocalDate start = parseYYYYMMDD(from, end.minusMonths(DUMMY_MONTHS_BACK));
+        if (start.isAfter(end)) start = end.minusDays(7);
 
-        // 2) 계좌 고정 시드 (안정적 생성)
         long baseSeed = Objects.hash(userId, accountId) * 0x9E3779B97F4A7C15L;
-
-        // 3) 시작 잔액 (계좌별 결정적)
         BigDecimal balance = initialBalance(accountId);
 
         List<NhAccountTransactionResponseDto> out = new ArrayList<>();
         YearMonth curYm = null;
-        BigDecimal monthVarRemain = BigDecimal.ZERO; // 월 변수 예산 남은액
+        BigDecimal monthVarRemain = BigDecimal.ZERO;
         int daysLeftInMonth = 0;
         LocalDate paydayDate = null;
         BigDecimal salaryAmt = BigDecimal.ZERO;
 
         for (LocalDate d = start; !d.isAfter(end); d = d.plusDays(1)) {
             YearMonth ym = YearMonth.from(d);
-
-            // 월 시작: 월간 계획 세팅
             if (!ym.equals(curYm)) {
                 curYm = ym;
-
                 long monthSeed = baseSeed ^ (ym.getYear() * 100 + ym.getMonthValue());
                 SplittableRandom mr = new SplittableRandom(monthSeed);
 
-                // 급여 (2.0M ~ 3.5M), 급여일 보정(주말 -> 직전 평일)
                 salaryAmt = bd(2_000_000 + mr.nextInt(1_500_000));
                 paydayDate = adjustToWeekday(ym.atDay(Math.min(PAYDAY, ym.lengthOfMonth())));
 
-                // 고정비 총합
                 BigDecimal fixedSum = FIXED_BILLS.stream().map(fb -> fb.amt).reduce(BigDecimal.ZERO, BigDecimal::add);
-
-                // 기본 계획 변수예산
-                BigDecimal percent = bd(55 + mr.nextInt(31)); // 55~85%
+                BigDecimal percent = bd(55 + mr.nextInt(31));
                 BigDecimal plannedVar = salaryAmt.multiply(percent).divide(bd(100))
                         .add(bd(100_000 + mr.nextInt(300_000)));
 
-                // 실제 가능액 = 현재잔액 + 급여 - 고정비 (음수면 0)
                 BigDecimal availableThisMonth = balance.add(salaryAmt).subtract(fixedSum);
                 if (availableThisMonth.signum() < 0) availableThisMonth = BigDecimal.ZERO;
 
-                // 월 변수예산을 실제 가능액 이하로 제한
                 monthVarRemain = plannedVar.min(availableThisMonth);
-
-                // 해당 월 남은 일수
                 daysLeftInMonth = ym.lengthOfMonth() - d.getDayOfMonth() + 1;
             }
 
-            // 날짜별 시드
             SplittableRandom dr = new SplittableRandom(baseSeed ^ d.toEpochDay());
 
-            // 급여
             if (d.equals(paydayDate)) {
                 balance = balance.add(salaryAmt);
                 out.add(buildDto(userId, accountId, randomTime(dr, d), true, salaryAmt, balance,
                         "급여", "월급", makeTuNo(accountId, d, 0)));
             }
 
-            // 고정비 (부족 시 자동 충전 → 출금)
             for (FixedBill fb : FIXED_BILLS) {
                 if (d.getDayOfMonth() == fb.day) {
                     if (balance.compareTo(fb.amt) < 0) {
@@ -204,10 +206,9 @@ public class NhAccountServiceImpl implements NhAccountService {
                 }
             }
 
-            // 일상 소비 — 월 변수 예산을 일 목표로 분배, 잔액-세이프티 한도 내에서만 지출
             int dailyCnt = MIN_DAILY + dr.nextInt(MAX_DAILY - MIN_DAILY + 1);
             if (d.getDayOfWeek() == DayOfWeek.FRIDAY || d.getDayOfWeek() == DayOfWeek.SATURDAY) {
-                dailyCnt += dr.nextInt(3); // 주말 +0~2건
+                dailyCnt += dr.nextInt(3);
             }
             dailyCnt = Math.max(MIN_DAILY, Math.min(MAX_DAILY + 2, dailyCnt));
 
@@ -222,7 +223,6 @@ public class NhAccountServiceImpl implements NhAccountService {
             BigDecimal spentToday = BigDecimal.ZERO;
 
             for (int i = 0; i < dailyCnt; i++) {
-                // 오늘 남은 목표 vs. 당장 지출 가능 최대(잔액-세이프티)
                 BigDecimal remainGoal = plannedToday.subtract(spentToday);
                 BigDecimal availToSpend = balance.subtract(SAFETY);
                 BigDecimal remain = min(remainGoal, availToSpend);
@@ -236,7 +236,7 @@ public class NhAccountServiceImpl implements NhAccountService {
                 BigDecimal amt = MIN_TX.add(bd(new SplittableRandom(baseSeed ^ (d.toEpochDay() + i))
                         .nextInt(capInt - MIN_TX.intValue() + 1)));
 
-                boolean isIncome = new SplittableRandom(baseSeed ^ (d.toEpochDay() * 13 + i)).nextInt(22) == 0; // 가끔 환불/입금
+                boolean isIncome = new SplittableRandom(baseSeed ^ (d.toEpochDay() * 13 + i)).nextInt(22) == 0;
                 LocalDateTime when = randomTime(dr, d);
 
                 if (isIncome) {
@@ -244,7 +244,6 @@ public class NhAccountServiceImpl implements NhAccountService {
                     out.add(buildDto(userId, accountId, when, true, amt, balance,
                             "이체입금", MEMOS.get(dr.nextInt(MEMOS.size())), makeTuNo(accountId, d, 1000 + i)));
                 } else {
-                    // 지출 후에도 SAFETY 유지
                     if (balance.subtract(amt).compareTo(SAFETY) < 0) break;
                     balance = balance.subtract(amt);
                     spentToday = spentToday.add(amt);
@@ -256,50 +255,34 @@ public class NhAccountServiceImpl implements NhAccountService {
 
             monthVarRemain = max(BigDecimal.ZERO, monthVarRemain.subtract(spentToday));
             daysLeftInMonth--;
-            // rescue 입금 필요 없음 (마이너스 구조 자체 차단)
         }
 
         out.sort(Comparator.comparing(NhAccountTransactionResponseDto::getDate));
         return out;
     }
 
-    /* ===== Helper ===== */
+    // ===== Helper (그대로) =====
     private static BigDecimal bd(long v) { return BigDecimal.valueOf(v); }
     private static BigDecimal bd(int v)  { return BigDecimal.valueOf(v); }
     private static BigDecimal max(BigDecimal a, BigDecimal b){ return a.compareTo(b) >= 0 ? a : b; }
     private static BigDecimal min(BigDecimal a, BigDecimal b){ return a.compareTo(b) <= 0 ? a : b; }
-    private static BigDecimal clamp(BigDecimal v, BigDecimal lo, BigDecimal hi){
-        return max(lo, min(hi, v));
-    }
+    private static BigDecimal clamp(BigDecimal v, BigDecimal lo, BigDecimal hi){ return max(lo, min(hi, v)); }
     private static LocalDate min(LocalDate a, LocalDate b){ return a.isBefore(b) ? a : b; }
-
     private static LocalDate adjustToWeekday(LocalDate date) {
         DayOfWeek dow = date.getDayOfWeek();
         if (dow == DayOfWeek.SATURDAY) return date.minusDays(1);
         if (dow == DayOfWeek.SUNDAY)   return date.minusDays(2);
         return date;
     }
-
-    private NhAccountTransactionResponseDto buildDto(
-            Long userId, Long accountId, LocalDateTime when, boolean income,
-            BigDecimal amount, BigDecimal balance, String place, String memo, long tuNo
-    ) {
+    private NhAccountTransactionResponseDto buildDto(Long userId, Long accountId, LocalDateTime when, boolean income,
+                                                     BigDecimal amount, BigDecimal balance, String place, String memo, long tuNo) {
         return NhAccountTransactionResponseDto.builder()
-                .userId(userId)
-                .accountId(accountId)
-                .date(when)
+                .userId(userId).accountId(accountId).date(when)
                 .type(income ? "INCOME" : "EXPENSE")
-                .amount(amount)
-                .balance(balance)
-                .place(place)
-                .isCancelled(false)
-                .tuNo(tuNo)
-                .memo(memo)
-                .category(null)
-                .analysis(null)
-                .build();
+                .amount(amount).balance(balance).place(place)
+                .isCancelled(false).tuNo(tuNo).memo(memo)
+                .category(null).analysis(null).build();
     }
-
     private static LocalDate parseYYYYMMDD(String yyyymmdd, LocalDate fallback) {
         try { return LocalDate.parse(yyyymmdd, DateTimeFormatter.BASIC_ISO_DATE); }
         catch (Exception e) { return fallback; }
@@ -318,7 +301,6 @@ public class NhAccountServiceImpl implements NhAccountService {
     }
     private static BigDecimal initialBalance(Long accountId) {
         long h = Math.abs(Objects.hashCode(accountId));
-        // 0.8M ~ 2.8M 사이 결정적 시작 잔액
         return bd(800_000 + (h % 2_000_000));
     }
 }

--- a/src/main/java/org/scoula/nhapi/service/NhCardServiceImpl.java
+++ b/src/main/java/org/scoula/nhapi/service/NhCardServiceImpl.java
@@ -63,8 +63,8 @@ public class NhCardServiceImpl implements NhCardService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final int CARD_DUMMY_MONTHS_BACK = 6;
-    private static final int CARD_MIN_DAILY = 1;
-    private static final int CARD_MAX_DAILY = 8;          // ✅ 생성량 완화
+    private static final int CARD_MIN_DAILY = 0;
+    private static final int CARD_MAX_DAILY = 6;          // ✅ 생성량 완화
 
 
     // ✅ 날짜별 고정 시드 → 기간 창이 달라도 동일 승인 생성(중복 방지)

--- a/src/main/java/org/scoula/nhapi/util/AccountBrandingUtil.java
+++ b/src/main/java/org/scoula/nhapi/util/AccountBrandingUtil.java
@@ -1,0 +1,27 @@
+package org.scoula.nhapi.util;
+
+import java.util.*;
+
+public final class AccountBrandingUtil {
+    public record AccountBranding(
+            String bankCode, String bankName, String accountType,
+            String productName, String accountNumber) {}
+
+    // 입출금(=DEPOSIT)
+    public static AccountBranding pickDeposit(long userId) {
+        Random r = BankCatalog.rng(userId, "acct:deposit");
+        var bank = BankCatalog.BANKS.get(r.nextInt(BankCatalog.BANKS.size()));
+        String prod = bank.demand[r.nextInt(bank.demand.length)];
+        String acct = String.format("%s-%04d-%06d", bank.code, r.nextInt(10_000), r.nextInt(1_000_000));
+        return new AccountBranding(bank.code, bank.name, "DEPOSIT", prod, acct);
+    }
+
+    // 저축(=SAVING)
+    public static AccountBranding pickSaving(long userId) {
+        Random r = BankCatalog.rng(userId, "acct:saving");
+        var bank = BankCatalog.BANKS.get(r.nextInt(BankCatalog.BANKS.size()));
+        String prod = bank.saving[r.nextInt(bank.saving.length)];
+        String acct = String.format("%s-%04d-%06d", bank.code, r.nextInt(10_000), r.nextInt(1_000_000));
+        return new AccountBranding(bank.code, bank.name, "SAVING", prod, acct);
+    }
+}

--- a/src/main/java/org/scoula/nhapi/util/BankCatalog.java
+++ b/src/main/java/org/scoula/nhapi/util/BankCatalog.java
@@ -1,5 +1,4 @@
-package org.scoula.account.util;
-
+package org.scoula.nhapi.util;
 import java.util.*;
 
 public final class BankCatalog {
@@ -8,8 +7,8 @@ public final class BankCatalog {
         public final String[] demand, saving, cardCredit, cardDebit, bins;
         public Bank(String code, String name, String[] demand, String[] saving,
                     String[] cardCredit, String[] cardDebit, String[] bins) {
-            this.code = code; this.name = name; this.demand = demand; this.saving = saving;
-            this.cardCredit = cardCredit; this.cardDebit = cardDebit; this.bins = bins;
+            this.code=code; this.name=name; this.demand=demand; this.saving=saving;
+            this.cardCredit=cardCredit; this.cardDebit=cardDebit; this.bins=bins;
         }
     }
 
@@ -20,36 +19,42 @@ public final class BankCatalog {
                     new String[]{"국민 톡톡","리브메이트"},
                     new String[]{"국민 노리체크","리브 체크"},
                     new String[]{"7018","5311"}),
+
             new Bank("088","신한은행",
                     new String[]{"신한 주거래 통장","신한 Deep 통장","신한 플러스 통장"},
                     new String[]{"신한 자유적금","신한 정기적금","신한 청년우대형 적금"},
                     new String[]{"신한 Deep","Mr.Life"},
                     new String[]{"신한 체크","S20 체크"},
                     new String[]{"9410","4305"}),
+
             new Bank("020","우리은행",
                     new String[]{"우리 WON 통장","우리 주거래 통장"},
                     new String[]{"우리 자유적금","우리 정기적금","우리 청년 적금"},
                     new String[]{"카드의정석","WON 카드"},
                     new String[]{"우리 체크","WON 체크"},
                     new String[]{"4573","4048"}),
+
             new Bank("081","하나은행",
                     new String[]{"하나 1Q 통장","하나 주거래 통장"},
                     new String[]{"하나 자유적금","하나 정기적금","하나 청년 적금"},
                     new String[]{"하나 1Q","멤버스"},
                     new String[]{"하나 체크","1Q 체크"},
                     new String[]{"5540","4386"}),
+
             new Bank("011","NH농협은행",
                     new String[]{"NH 올원 입출금","NH 주거래 통장"},
                     new String[]{"NH 올원 적금","NH 자유적금","NH 청년희망 적금"},
                     new String[]{"올바른 카드"},
                     new String[]{"올원 체크"},
                     new String[]{"3560","5399"}),
+
             new Bank("090","카카오뱅크",
                     new String[]{"카카오 입출금","세이프박스"},
                     new String[]{"카카오 자유적금","카카오 정기예금"},
                     new String[]{"카카오뱅크 카드"},
                     new String[]{"카카오뱅크 체크"},
                     new String[]{"4704","5559"}),
+
             new Bank("092","토스뱅크",
                     new String[]{"토스통장","먼슬리통장"},
                     new String[]{"먼슬리적금","토스 자유적금"},

--- a/src/main/java/org/scoula/nhapi/util/CardBrandingUtil.java
+++ b/src/main/java/org/scoula/nhapi/util/CardBrandingUtil.java
@@ -1,0 +1,16 @@
+package org.scoula.nhapi.util;
+
+import java.util.*;
+
+public final class CardBrandingUtil {
+    public record CardBranding(String bankName, String cardName, String masked, String cardType) {}
+
+    public static CardBranding pickForUser(long userId, boolean credit) {
+        Random r = BankCatalog.rng(userId, "cardBrand:" + (credit?"C":"D"));
+        var bank = BankCatalog.BANKS.get(r.nextInt(BankCatalog.BANKS.size()));
+        String name = (credit ? bank.cardCredit : bank.cardDebit)[r.nextInt(credit ? bank.cardCredit.length : bank.cardDebit.length)];
+        String bin  = bank.bins[r.nextInt(bank.bins.length)];
+        String masked = String.format("%s-****-****-%04d", bin, 1000 + r.nextInt(9000));
+        return new CardBranding(bank.name, name, masked, credit ? "CREDIT" : "DEBIT");
+    }
+}

--- a/src/main/java/org/scoula/nhapi/util/FirstLinkOnboardingService.java
+++ b/src/main/java/org/scoula/nhapi/util/FirstLinkOnboardingService.java
@@ -1,0 +1,117 @@
+package org.scoula.nhapi.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.scoula.account.domain.Account;
+import org.scoula.account.mapper.AccountMapper;
+import org.scoula.card.domain.Card;
+import org.scoula.card.mapper.CardMapper;
+import org.scoula.nhapi.client.NHApiClient;
+import org.scoula.transactions.service.CardTransactionService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FirstLinkOnboardingService {
+
+    private final NHApiClient nhApiClient;
+    private final AccountMapper accountMapper;
+    private final CardMapper cardMapper;
+    private final CardTransactionService cardTxService;
+
+    private static final int MIN_DEPOSIT = 2, MAX_DEPOSIT = 3;
+    private static final int MIN_SAVING  = 1, MAX_SAVING  = 2;
+    private static final int MIN_CARDS   = 2, MAX_CARDS   = 3;
+
+    @Transactional
+    public void runOnceOnFirstLink(Long userId) {
+        Random r = new Random(java.util.Objects.hash(userId, "first-pack"));
+
+        int targetDeposit = MIN_DEPOSIT + r.nextInt(MAX_DEPOSIT - MIN_DEPOSIT + 1);
+        int targetSaving  = MIN_SAVING  + r.nextInt(MAX_SAVING  - MIN_SAVING  + 1);
+        int targetCards   = MIN_CARDS   + r.nextInt(MAX_CARDS   - MIN_CARDS   + 1);
+
+        int curDeposit = accountMapper.countByUserAndType(userId, "DEPOSIT");
+        int curSaving  = accountMapper.countByUserAndType(userId, "SAVING");
+        int curCards   = cardMapper.countByUser(userId);
+
+        int mkDeposit = Math.max(0, targetDeposit - curDeposit);
+        int mkSaving  = Math.max(0, targetSaving  - curSaving);
+        int mkCards   = Math.max(0, targetCards  - curCards);
+
+        log.info("🎁 Onboarding (user={}): make DEPOSIT +{}, SAVING +{}, CARDS +{}", userId, mkDeposit, mkSaving, mkCards);
+
+        for (int i = 0; i < mkDeposit; i++) createDeposit(userId);
+        for (int i = 0; i < mkSaving;  i++) createSaving(userId);
+        for (int i = 0; i < mkCards;   i++) createCard(userId);
+    }
+
+    private void createDeposit(Long userId) {
+        var b = AccountBrandingUtil.pickDeposit(userId);
+        String finAcno = nhApiClient.callCheckFinAccount("RG" + System.nanoTime(), "19900101").optString("FinAcno");
+
+        BigDecimal balance = new BigDecimal(nhApiClient.callInquireBalance(finAcno).optString("Ldbl", "900000"));
+
+        Account acc = Account.builder()
+                .userId(userId)
+                .pinAccountNumber(finAcno)
+                .bankCode(b.bankCode())
+                .accountNumber(b.accountNumber())
+                .productName(b.productName())
+                .accountType("DEPOSIT")
+                .balance(balance)
+                .isActive(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+        accountMapper.insert(acc);
+        log.info("🌱 DEPOSIT created: {} / {}", b.bankCode(), b.productName());
+    }
+
+    private void createSaving(Long userId) {
+        var b = AccountBrandingUtil.pickSaving(userId);
+        String finAcno = nhApiClient.callCheckFinAccount("RG" + System.nanoTime(), "19900101").optString("FinAcno");
+
+        Account acc = Account.builder()
+                .userId(userId)
+                .pinAccountNumber(finAcno)
+                .bankCode(b.bankCode())
+                .accountNumber(b.accountNumber())
+                .productName(b.productName())
+                .accountType("SAVING")
+                .balance(BigDecimal.ZERO)
+                .isActive(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+        accountMapper.insert(acc);
+        log.info("🌱 SAVING created: {} / {}", b.bankCode(), b.productName());
+    }
+
+    private void createCard(Long userId) {
+        var b = CardBrandingUtil.pickForUser(userId, true);
+        JSONObject open = nhApiClient.callOpenFinCard("MOCK-" + System.nanoTime(), "19990101");
+        String rgno = open.optString("Rgno");
+        String finCard = nhApiClient.checkOpenFinCard(rgno, "19990101").optString("FinCard");
+
+        Card card = Card.builder()
+                .userId(userId)
+                .finCardNumber(finCard)
+                .backCode("00")
+                .bankName(b.bankName())
+                .cardName(b.cardName())
+                .cardMaskednum(b.masked())
+                .cardMemberType("SELF")
+                .cardType(b.cardType())
+                .isActive(true)
+                .build();
+        cardMapper.insertCard(card);
+        
+        log.info("🌱 CARD created: {} {}", b.bankName(), b.cardName());
+    }
+}

--- a/src/main/resources/org/scoula/account/mapper/AccountMapper.xml
+++ b/src/main/resources/org/scoula/account/mapper/AccountMapper.xml
@@ -42,6 +42,10 @@
         WHERE id = #{accountId}
     </select>
 
+    <select id="countByUserAndType" resultType="int">
+        SELECT COUNT(1) FROM account WHERE user_id=#{userId} AND account_type=#{type} AND is_active = TRUE
+    </select>
+
     <select id="findActiveByUserId" resultType="org.scoula.account.domain.Account">
         SELECT id, user_id, pin_account_number, bank_code, account_number,
                product_name, account_type, balance, created_at

--- a/src/main/resources/org/scoula/card/mapper/CardMapper.xml
+++ b/src/main/resources/org/scoula/card/mapper/CardMapper.xml
@@ -4,7 +4,8 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.scoula.card.mapper.CardMapper">
-    <insert id="insertCard" parameterType="org.scoula.card.domain.Card">
+    <insert id="insertCard" parameterType="org.scoula.card.domain.Card"
+            useGeneratedKeys="true" keyProperty="id">
         INSERT INTO card (
             user_id, fin_card_number, back_code, bank_name, card_name,
             card_maskednum, card_member_type, card_type, is_active
@@ -40,5 +41,10 @@
             #{id}
         </foreach>
     </select>
+
+    <select id="countByUser" resultType="int">
+        SELECT COUNT(1) FROM account WHERE user_id=#{userId} AND is_active = TRUE
+    </select>
+
 
 </mapper>

--- a/src/main/resources/org/scoula/transactions/mapper/AccountTransactionMapper.xml
+++ b/src/main/resources/org/scoula/transactions/mapper/AccountTransactionMapper.xml
@@ -39,7 +39,7 @@
     <select id="findLastTransactionDate" resultType="java.time.LocalDateTime">
         SELECT MAX(date)
         FROM account_transaction
-        WHERE account_id = #{accountId}
+        WHERE account_id = #{accountId} AND user_id = #{userId}
     </select>
 
     <insert id="bulkInsert" parameterType="list">

--- a/src/main/resources/org/scoula/transactions/mapper/CardTransactionMapper.xml
+++ b/src/main/resources/org/scoula/transactions/mapper/CardTransactionMapper.xml
@@ -52,7 +52,7 @@
 
     <!-- 마지막 승인일 -->
     <select id="findLastTransactionDate" resultType="java.time.LocalDateTime">
-        SELECT MAX(approved_at) FROM card_transaction WHERE card_id = #{cardId}
+        SELECT MAX(approved_at) FROM card_transaction WHERE card_id = #{cardId} AND user_id = #{userId}
     </select>
 
     <select id="sumMonthlySpending" resultType="java.math.BigDecimal">


### PR DESCRIPTION
# 📌 Pull Request

## 👀 작업 요약 

## 📖 작업 내용 
프론트에서 “자산 연동”을 누르면 실제 NH 발급 절차(핀계좌·핀카드·토큰)를 호출하지 않고, 서버가 mock 모드에서 DB에 보관된 핀계좌/핀카드 값을 재사용하여 즉시 등록·동기화가 완료된 것처럼 동작하게 한다.
한 번 저장된 핀계좌/핀카드 값은 **항상 재사용(재발급 생략)**하며, 기본 시드(기본 3계좌+2카드, 필요 시 heavy 5+4)와 거래 더미를 멱등 업서트로 주입한다.

## ✅ 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 로컬 환경에서 동작 확인 완료
- [ ] 리뷰어 n명 이상 승인 완료
- [ ] 문서화가 필요한 경우 추가했습니다.
- [ ] 관련 이슈가 있다면 연결했습니다. (ex: `#12`)

## ✋ 질문 사항

## 🔗 관련 이슈
closes 235
- 관련된 이슈 번호를 연결해주세요. (예: closes #1234)
